### PR TITLE
Only mark argparse as required for versions of Python without argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,13 @@
 import glob
 from setuptools import setup, find_packages
 
+install_requires = ['distribute']
+
+try:
+    import argparse
+except ImportError:
+    install_requires.append('argparse')
+
 setup(
     name='argcomplete',
     version='0.3.9',
@@ -12,7 +19,7 @@ setup(
     author_email='kislyuk@gmail.com',
     description='Bash tab completion for argparse',
     long_description=open('README.rst').read(),
-    install_requires=['distribute', 'argparse'],
+    install_requires=install_requires,
     packages = find_packages(),
     scripts = glob.glob('scripts/*'),
     package_data={'argcomplete': ['bash_completion.d/python-argcomplete.sh']},


### PR DESCRIPTION
Conditionally include argparse as a requirement only for versions of
Python that do not have argparse already bundled.

This should be a little better fix than the one in 478b6fcb21a55bab9f2589c8204b72c8485fb383
