### PR TITLE
Coverage testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
 before_install:
     - pip install --quiet coverage
 
+install:
+    - python setup.py install
+
 script:
     - make test
     - coverage run --omit='*/site-packages/*,*/distutils/*' ./test/test.py


### PR DESCRIPTION
This enables [Coveralls](https://coveralls.io) based coverage testing.

See [example output](https://coveralls.io/r/myint/argcomplete). Note that this has already found one [error](https://coveralls.io/builds/17772/source?filename=test%2Ftest.py). `test_basic_completion()` is defined twice in the same class.
