### PR TITLE
# this resolves issues 34 and 37

### DIFF
--- a/scripts/python-argcomplete-check-easy-install-script
+++ b/scripts/python-argcomplete-check-easy-install-script
@@ -26,7 +26,7 @@ with open(args.wrapper_script) as fh:
             dist, group, name = re.match("# EASY-INSTALL-ENTRY-SCRIPT: '(.+)','(.+)','(.+)'", line).groups()
             import pkgutil
             module_name = pkg_resources.get_distribution(dist).get_entry_info(group, name).module_name
-            with open(pkgutil.get_loader(module_name).filename) as mod_fh:
+            with open(pkgutil.get_loader(module_name).get_filename()) as mod_fh:
                 if "PYTHON_ARGCOMPLETE_OK" in mod_fh.read(1024):
                     exit(0)
 


### PR DESCRIPTION
#34 pkgutil.get_loader().filename can be a directory
#37: error while running python-argcomplete-check-easy-install-script on python 3.3
