### PR TITLE
tox: added tox.ini 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py26,py27,py33
+
+[testenv]
+deps=pytest
+changedir=test
+commands=py.test test.py
+


### PR DESCRIPTION
Can be used with the `tox` tool from http://testrun.org/tox/latest/  (or `pip install tox`).

Tests 2.6, 2.7 and 3.3 in their own virtualenvs.
