### PR TITLE
tox: - added dependency on unittest2 for py26

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py26,py27,py33
+
+[testenv]
+deps=pytest
+changedir=test
+commands=py.test test.py
+
+[testenv:py26]
+deps=
+  pytest
+  unittest2
+changedir=test
+commands=py.test test.py


### PR DESCRIPTION
will test 2.6, 2.7 and 3.3 in their own virtualenvs with tox ( http://testrun.org/tox/, install with `pip install tox`)
This assumes you have those versions of Python installed locally 
