### PR TITLE
travis-unittest2: added unittest2, use mirrors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
     - 3.3
 
 before_install:
-    - pip install --quiet coverage
+    - pip install --quiet --use-mirrors coverage unittest2
 
 install:
     - python setup.py install


### PR DESCRIPTION
--use-mirrors is recommended http://about.travis-ci.org/docs/user/languages/python/#Pre-installed-packages

unaccessible PyPI is what caused PR #44 to fail, 
