### PR TITLE
pytest: using pytest for testing (instead of unittest)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ python:
     - pypy
 
 before_install:
-    - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip --quiet install unittest2; fi
-    - pip install --quiet coverage
+    - pip install --quiet coverage --use-mirrors
 
 install:
     - python setup.py install

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # TODO: pyflakes?
 test:
 	-pylint -E argcomplete
-	./setup.py test --test-suite test.test.TestArgcomplete
+	./setup.py test
 
 test3:
-	python3 ./test/test.py -v
+	python3 setup.py test
 
 release: docs
 	python setup.py sdist upload -s -i D2069255

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import glob
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Command
 
 install_requires = []
 
@@ -9,6 +9,17 @@ try:
     import argparse
 except ImportError:
     install_requires.append('argparse')
+
+class PyTest(Command):
+    user_options = []
+    def initialize_options(self):
+        pass
+    def finalize_options(self):
+        pass
+    def run(self):
+        import sys,subprocess
+        errno = subprocess.call([sys.executable, '-m', 'pytest', 'test'])
+        raise SystemExit(errno)
 
 setup(
     name='argcomplete',
@@ -26,6 +37,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms=['MacOS X', 'Posix'],
+    cmdclass = { 'test': PyTest },
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',

--- a/test/test_argcomplete.py
+++ b/test/test_argcomplete.py
@@ -3,12 +3,7 @@
 import locale
 import os
 import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    import unittest2 as unittest
-import shutil
-from tempfile import TemporaryFile, mkdtemp
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -17,58 +12,35 @@ from argcomplete import *
 
 IFS = '\013'
 
-class TempDir(object):
-    """temporary directory for testing FilesCompletion
+class TestArgcomplete:
 
-    usage:
-    with TempDir(prefix="temp_fc") as t:
-        print('tempdir', t)
-        # you are not chdir-ed to the temporary directory
-        # everything created here will be deleted
-    """
-    def __init__(self, suffix="", prefix='tmpdir', dir=None):
-        self.tmp_dir = mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
-        self.old_dir = os.getcwd()
-
-    def __enter__(self):
-        os.chdir(self.tmp_dir)
-        return self.tmp_dir
-
-    def __exit__(self, *err):
-        os.chdir(self.old_dir)
-        shutil.rmtree(self.tmp_dir)
-
-
-class TestArgcomplete(unittest.TestCase):
-
-    def setUp(self):
-        os.environ['_ARGCOMPLETE'] = "yes"
-        os.environ['_ARC_DEBUG'] = "yes"
-        os.environ['IFS'] = IFS
-
-    def tearDown(self):
-        pass
-
-    def run_completer(self, parser, command, point=None):
-        with TemporaryFile() as t:
-            #os.environ['COMP_LINE'] = command.encode(locale.getpreferredencoding())
-            os.environ['COMP_LINE'] = command
-            os.environ['COMP_POINT'] = point if point else str(len(command))
-            os.environ['COMP_WORDBREAKS'] = '"\'@><=;|&(:'
-            self.assertRaises(SystemExit, autocomplete, parser, output_stream=t,
+    def run_completer(self, parser, command, point=None,
+                      tmpdir=None, monkeypatch=None):
+        with open('testfile', 'wb+') as t:
+            if monkeypatch is not None:
+                monkeypatch.setenv('_ARGCOMPLETE', "yes")
+                monkeypatch.setenv('_ARC_DEBUG', "yes")
+                monkeypatch.setenv('IFS', IFS)
+                #os.environ['COMP_LINE'] = command.encode(locale.getpreferredencoding())
+                monkeypatch.setenv('COMP_LINE', command)
+                monkeypatch.setenv('COMP_POINT', point if point else str(len(command)))
+                monkeypatch.setenv('COMP_WORDBREAKS', '"\'@><=;|&(:')
+            with pytest.raises(SystemExit):
+                autocomplete(parser, output_stream=t,
                               exit_method=sys.exit)
             t.seek(0)
             return t.read().decode(locale.getpreferredencoding()).split(IFS)
 
-    def test_basic_completion(self):
+    def test_basic_completion(self, tmpdir, monkeypatch):
         p = ArgumentParser()
         p.add_argument("--foo")
         p.add_argument("--bar")
 
-        completions = self.run_completer(p, "prog ")
+        completions = self.run_completer(p, "prog ", tmpdir=tmpdir,
+                                         monkeypatch=monkeypatch)
         assert(set(completions) == set(['-h', '--help', '--foo', '--bar']))
 
-    def test_completers(self):
+    def test_completers(self, tmpdir, monkeypatch):
         def c_url(prefix, parsed_args, **kwargs):
             return [ "http://url1", "http://url2" ]
 
@@ -88,21 +60,24 @@ class TestArgcomplete(unittest.TestCase):
             )
 
         for cmd, output in expected_outputs:
-            self.assertEqual(set(self.run_completer(make_parser(), cmd)), set(output))
+            assert set(self.run_completer(make_parser(), cmd,
+                                          tmpdir=tmpdir,
+                                          monkeypatch=monkeypatch),
+                       ) == set(output)
 
-    def test_file_completion(self):
+    def test_file_completion(self, tmpdir):
         # setup and teardown should probably be in class
         from argcomplete.completers import FilesCompleter
-        with TempDir(prefix='test_dir_fc', dir='.') as t:
-            fc = FilesCompleter()
-            os.makedirs(os.path.join('abcdef', 'klm'))
-            self.assertEqual(fc('a'), ['abcdef/'])
-            os.makedirs(os.path.join('abcaha', 'klm'))
-            with open('abcxyz', 'w') as fp:
-                fp.write('test')
-            self.assertEqual(set(fc('a')), set(['abcdef/', 'abcaha/', 'abcxyz']))
+        tmpdir.chdir()
+        fc = FilesCompleter()
+        os.makedirs(os.path.join('abcdef', 'klm'))
+        assert fc('a') == ['abcdef/']
+        os.makedirs(os.path.join('abcaha', 'klm'))
+        with open('abcxyz', 'w') as fp:
+            fp.write('test')
+        assert set(fc('a')) == set(['abcdef/', 'abcaha/', 'abcxyz'])
 
-    def test_subparsers(self):
+    def test_subparsers(self, tmpdir, monkeypatch):
         def make_parser():
             parser = argparse.ArgumentParser()
             parser.add_argument("--age", type=int)
@@ -123,11 +98,14 @@ class TestArgcomplete(unittest.TestCase):
             )
 
         for cmd, output in expected_outputs:
-            self.assertEqual(set(self.run_completer(make_parser(), cmd)), set(output))
+            assert set(self.run_completer(make_parser(), cmd,
+                                          tmpdir=tmpdir,
+                                          monkeypatch=monkeypatch)
+                       ) == set(output)
 
-    if sys.version_info >= (2, 7):
-        @unittest.skip("currently works on either 2 or 3, but not both")
-        def test_non_ascii(self):
+        @pytest.mark.skipif(sys.version_info >= (2, 6))
+        #currently works on either 2 or 3, but not both
+        def test_non_ascii(self, tmpdir, monkeypatch):
             def make_parser():
                 parser = argparse.ArgumentParser()
                 parser.add_argument('--книга', choices=['Трудно быть богом', 'Парень из преисподней', 'Понедельник начинается в субботу'])
@@ -141,7 +119,7 @@ class TestArgcomplete(unittest.TestCase):
 
             for cmd, output in expected_outputs:
                 output = [o.decode(locale.getpreferredencoding()) for o in output]
-                self.assertEqual(set(self.run_completer(make_parser(), cmd)), set(output))
-
-if __name__ == '__main__':
-    unittest.main()
+                assert set(self.run_completer(make_parser(), cmd,
+                                          tmpdir=tmpdir,
+                                          monkeypatch=monkeypatch)
+                           ) == set(output)

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = py26,py27,py33
+envlist = py26,py27,py33,pypy
 
 [testenv]
 deps=pytest
 changedir=test
-commands=py.test test.py
+commands=py.test 
 
 [testenv:py26]
 deps=
   pytest
   unittest2
 changedir=test
-commands=py.test test.py
+commands=py.test


### PR DESCRIPTION
- rename test/test.py to test/test_argcomplete.py to match pytest default
  file pattern (test_*).
- arcomplete.py:
  - remove dependency on unittest and unittest2
  - replace TempDir with fixture tmpdir
  - use monkeypatch fixture so env. changes are not global
- update setup.py, so that 'python setup.py test' results in running py.test
- update Makefile to run py.test on target test and test3
- update tox.ini to include pypy, and reflect change of test.py name
- remove unittest2 from travis

for motiviation see my comment on https://github.com/kislyuk/argcomplete/pull/47#issuecomment-22825865
