### PR TITLE
pytest: using pytest for testing (instead of unittest)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,14 @@ python:
     - pypy
 
 before_install:
-    - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip --quiet install unittest2; fi
-    - pip install --quiet coverage
+    - pip install --quiet coverage --use-mirrors
 
 install:
     - python setup.py install
 
 script:
     - make test
-    - coverage run --omit='*/site-packages/*,*/distutils/*' ./test/test.py
+    - coverage run --omit='*/site-packages/*,*/distutils/*' ./test/test_argcomplete.py
     - coverage report --show-missing
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # TODO: pyflakes?
 test:
 	-pylint -E argcomplete
-	./setup.py test --test-suite test.test.TestArgcomplete
+	./setup.py test
 
 test3:
-	python3 ./test/test.py -v
+	python3 setup.py test
 
 release: docs
 	python setup.py sdist upload -s -i D2069255

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import glob
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Command
 
 install_requires = []
 
@@ -9,6 +9,17 @@ try:
     import argparse
 except ImportError:
     install_requires.append('argparse')
+
+class PyTest(Command):
+    user_options = []
+    def initialize_options(self):
+        pass
+    def finalize_options(self):
+        pass
+    def run(self):
+        import sys,subprocess
+        errno = subprocess.call([sys.executable, '-m', 'pytest', 'test'])
+        raise SystemExit(errno)
 
 setup(
     name='argcomplete',
@@ -26,6 +37,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms=['MacOS X', 'Posix'],
+    cmdclass = { 'test': PyTest },
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = py26,py27,py33
+envlist = py26,py27,py33,pypy
 
 [testenv]
 deps=pytest
 changedir=test
-commands=py.test test.py
+commands=py.test 
 
 [testenv:py26]
 deps=
   pytest
   unittest2
 changedir=test
-commands=py.test test.py
+commands=py.test


### PR DESCRIPTION
- rename test/test.py to test/test_argcomplete.py to match pytest default
  file pattern (test_*).
- arcomplete.py:
  - remove dependency on unittest and unittest2
  - replace TempDir with fixture tmpdir
  - use monkeypatch fixture so env. changes are not global
- update setup.py, so that 'python setup.py test' results in running py.test
- update Makefile to run py.test on target test and test3
- update tox.ini to include pypy, and reflect change of test.py name
- remove unittest2 from travis

for motiviation see comment on: https://github.com/kislyuk/argcomplete/pull/47#issuecomment-22825865
