### PR TITLE
Remove the trailing space in completions with a single entry.

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -295,12 +295,6 @@ def autocomplete(argument_parser, always_complete_options=True, exit_method=os._
                 completions = [c.replace(char, '\\'+char) for c in completions]
         completions = [cword_prequote+c.replace(cword_prequote, '\\'+cword_prequote) for c in completions]
 
-    # If there's only one completion, and it's not open-quoted and doesn't end with a continuation char, add a space
-    continuation_chars = '=/:'
-    if len(completions) == 1 and completions[0][-1] not in continuation_chars:
-        if cword_prequote == '' and not completions[0].endswith(' '):
-            completions[0] += ' '
-
     # print >>debug_stream, "\nReturning completions:", [pipes.quote(c) for c in completions]
     # print ifs.join([pipes.quote(c) for c in completions])
     # print ifs.join([escape_completion_name_str(c) for c in completions])

--- a/argcomplete/bash_completion.d/python-argcomplete.sh
+++ b/argcomplete/bash_completion.d/python-argcomplete.sh
@@ -30,4 +30,4 @@ _python_argcomplete_global() {
         type -t _completion_loader | grep -q 'function' && _completion_loader "$@" 
     fi
 }
-complete -o nospace -o default -D -F _python_argcomplete_global
+complete -o default -D -F _python_argcomplete_global

--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -29,7 +29,7 @@ _python_argcomplete() {
         unset COMPREPLY
     fi
 }
-complete -o nospace -o default -F _python_argcomplete "%s"
+complete -o default -F _python_argcomplete "%s"
 '''
 
 parser = argparse.ArgumentParser(description=__doc__,


### PR DESCRIPTION
Use bash's built in mechanism instead.
See issue https://github.com/kislyuk/argcomplete/issues/50 for details. Works fine with bash and also with zsh now.
