### PR TITLE
Rename environment variable COMP_WORDBREAKS to _COMP_WORDBREAKS 

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -130,7 +130,7 @@ def autocomplete(argument_parser, always_complete_options=True, exit_method=os._
             exit_method(1)
 
     # print >>debug_stream, ""
-    # for v in 'COMP_CWORD', 'COMP_LINE', 'COMP_POINT', 'COMP_TYPE', 'COMP_KEY', '_COMP_WORDBREAKS', 'COMP_WORDS':
+    # for v in 'COMP_CWORD', 'COMP_LINE', 'COMP_POINT', 'COMP_TYPE', 'COMP_KEY', '_ARGCOMPLETE_COMP_WORDBREAKS', 'COMP_WORDS':
     #     print >>debug_stream, v, os.environ[v]
 
     ifs = os.environ.get('_ARGCOMPLETE_IFS', '\013')
@@ -139,7 +139,7 @@ def autocomplete(argument_parser, always_complete_options=True, exit_method=os._
         exit_method(1)
 
     comp_line = os.environ['COMP_LINE']
-    comp_wordbreaks = os.environ['_COMP_WORDBREAKS']
+    comp_wordbreaks = os.environ['_ARGCOMPLETE_COMP_WORDBREAKS']
     comp_point = int(os.environ['COMP_POINT'])
 
     cword_prequote, cword_prefix, cword_suffix, comp_words, first_colon_pos = split_line(comp_line, comp_point)

--- a/argcomplete/bash_completion.d/python-argcomplete.sh
+++ b/argcomplete/bash_completion.d/python-argcomplete.sh
@@ -20,7 +20,7 @@ _python_argcomplete_global() {
         COMPREPLY=( $(_ARGCOMPLETE_IFS="$IFS" \
             COMP_LINE="$COMP_LINE" \
             COMP_POINT="$COMP_POINT" \
-            _COMP_WORDBREAKS="$COMP_WORDBREAKS" \
+            _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
             _ARGCOMPLETE=$ARGCOMPLETE \
             "$1" 8>&1 9>&2 1>/dev/null 2>&1) )
         if [[ $? != 0 ]]; then

--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -21,8 +21,8 @@ _python_argcomplete() {
     local IFS='\013'
     COMPREPLY=( $(IFS="$IFS" \
                   COMP_LINE="$COMP_LINE" \
-                  _COMP_WORDBREAKS="$COMP_WORDBREAKS" \
                   COMP_POINT="$COMP_POINT" \
+                  _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
                   _ARGCOMPLETE=1 \
                   "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
     if [[ $? != 0 ]]; then

--- a/test/test.py
+++ b/test/test.py
@@ -54,7 +54,7 @@ class TestArgcomplete(unittest.TestCase):
             #os.environ['COMP_LINE'] = command.encode(locale.getpreferredencoding())
             os.environ['COMP_LINE'] = command
             os.environ['COMP_POINT'] = point if point else str(len(command))
-            os.environ['_COMP_WORDBREAKS'] = '"\'@><=;|&(:'
+            os.environ['_ARGCOMPLETE_COMP_WORDBREAKS'] = '"\'@><=;|&(:'
             self.assertRaises(SystemExit, autocomplete, parser, output_stream=t,
                               exit_method=sys.exit)
             t.seek(0)


### PR DESCRIPTION
Rename environment variable COMP_WORDBREAKS to _COMP_WORDBREAKS  to avoid breaking script running through a bash wrapper.

See issue #58
