### PR TITLE
Added completition support for PBR installed scripts

### DIFF
--- a/argcomplete/bash_completion.d/python-argcomplete.sh
+++ b/argcomplete/bash_completion.d/python-argcomplete.sh
@@ -15,7 +15,7 @@ _python_argcomplete_global() {
         fi
         if (head -c 1024 "$SCRIPT_NAME" | grep --quiet "PYTHON_ARGCOMPLETE_OK") >/dev/null 2>&1; then
             local ARGCOMPLETE=1
-        elif (head -c 1024 "$SCRIPT_NAME" | egrep --quiet "EASY-INSTALL-(SCRIPT|ENTRY-SCRIPT|DEV-SCRIPT)" \
+        elif (head -c 1024 "$SCRIPT_NAME" | egrep --quiet "(PBR Generated)|(EASY-INSTALL-(SCRIPT|ENTRY-SCRIPT|DEV-SCRIPT))" \
             && python-argcomplete-check-easy-install-script "$SCRIPT_NAME") >/dev/null 2>&1; then
             local ARGCOMPLETE=1
         fi

--- a/scripts/python-argcomplete-check-easy-install-script
+++ b/scripts/python-argcomplete-check-easy-install-script
@@ -29,5 +29,12 @@ with open(args.wrapper_script) as fh:
             with open(pkgutil.get_loader(module_name).get_filename()) as mod_fh:
                 if "PYTHON_ARGCOMPLETE_OK" in mod_fh.read(1024):
                     exit(0)
+        elif line.startswith("# PBR Generated"):
+            module = re.search("from (.*) import", lines).groups()[0]
+            import pkgutil
+            file_name = pkgutil.get_loader(module).filename
+            with open(file_name) as mod_fh:
+                if "PYTHON_ARGCOMPLETE_OK" in mod_fh.read(1024):
+                    exit(0)
 
 exit(1)


### PR DESCRIPTION
This change enables argcomplete to work with PBR generated entry points

PBR sample entry point below:

<pre>
#!/usr/bin/python
# PBR Generated from 'console_scripts'

import sys

from ceilometerclient.shell import main

if __name__ == "__main__":
    sys.exit(main())
</pre>
