### PR TITLE
Fixed side effect of monkey patching hindering REPL usage.

### DIFF
--- a/argcomplete/my_argparse.py
+++ b/argcomplete/my_argparse.py
@@ -12,13 +12,10 @@ def action_is_satisfied(action):
 
     if action.nargs == ONE_OR_MORE and num_consumed_args < 1:
         return False
+    elif action.nargs is None:
+        return num_consumed_args == 1
     else:
-        if action.nargs is None:
-            action.nargs = 1
-        try:
-            return num_consumed_args == action.nargs
-        except:
-            return True
+        return num_consumed_args == action.nargs
 
 def action_is_open(action):
     ''' Returns True if action could consume more arguments (i.e., its pattern is open).


### PR DESCRIPTION
I don't think this breaks anything and it fixes the nasty side effect of tampering with the action. This caused argparse to return a list of one argument instead of just returning the argument in some cases after auto-completion was run (in a REPL environment.)
