### PR TITLE
Added completer for directories

### DIFF
--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -85,7 +85,7 @@ class _FilteredFilesCompleter(object):
         A predicate accepts as its only argument a candidate path and either 
         accepts it or rejects it.
         '''
-        assert predicate and callable(predicate), 'Expected a callable predicate'
+        assert predicate, 'Expected a callable predicate'
         self.predicate = predicate
 
     def __call__(self, prefix, **kwargs):

--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -85,7 +85,7 @@ class _FilteredFilesCompleter(object):
         A predicate accepts as its only argument a candidate path and either 
         accepts it or rejects it.
         '''
-        assert predicate, 'Expected a predicate function'
+        assert predicate and callable(predicate), 'Expected a callable predicate'
         self.predicate = predicate
 
     def __call__(self, prefix, **kwargs):
@@ -96,15 +96,15 @@ class _FilteredFilesCompleter(object):
             names = os.listdir(target_dir or '.')
         except:
             return # empty iterator
-        incomplete_part = os.path.basename(prefix);
+        incomplete_part = os.path.basename(prefix)
         # Iterate on target_dir entries and filter on given predicate
         for name in names:
             if not name.startswith(incomplete_part):
-                continue;
+                continue
             candidate = os.path.join(target_dir, name)
             if not self.predicate(candidate):
-                continue;
-            yield candidate + '/' if os.path.isdir(candidate) else candidate;
+                continue
+            yield candidate + '/' if os.path.isdir(candidate) else candidate
 
 class DirectoriesCompleter(_FilteredFilesCompleter):
     

--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -77,3 +77,37 @@ class FilesCompleter(object):
                 completion += [f + '/' for f in anticomp]
         return completion
 
+class _FilteredFilesCompleter(object):
+    
+    def __init__(self, predicate):
+        '''Create the completer
+
+        A predicate accepts as its only argument a candidate path and either 
+        accepts it or rejects it.
+        '''
+        assert predicate, 'Expected a predicate function'
+        self.predicate = predicate
+
+    def __call__(self, prefix, **kwargs):
+        '''Provide completions on prefix
+        '''
+        target_dir = os.path.dirname(prefix)
+        try:
+            names = os.listdir(target_dir or '.')
+        except:
+            return # empty iterator
+        incomplete_part = os.path.basename(prefix);
+        # Iterate on target_dir entries and filter on given predicate
+        for name in names:
+            if not name.startswith(incomplete_part):
+                continue;
+            candidate = os.path.join(target_dir, name)
+            if not self.predicate(candidate):
+                continue;
+            yield candidate + '/' if os.path.isdir(candidate) else candidate;
+
+class DirectoriesCompleter(_FilteredFilesCompleter):
+    
+    def __init__(self):
+        _FilteredFilesCompleter.__init__(self, predicate=os.path.isdir)
+

--- a/test/test.py
+++ b/test/test.py
@@ -183,6 +183,30 @@ class TestArgcomplete(unittest.TestCase):
                 fp.write('test')
             self.assertEqual(set(fc('a')), set(['abcdef/', 'abcaha/', 'abcxyz']))
 
+    def test_directory_completion(self):
+        from argcomplete.completers import DirectoriesCompleter
+        completer = DirectoriesCompleter()
+        c = lambda prefix: set(completer(prefix))
+        with TempDir(prefix='test_dir', dir='.') as temp_dir:
+            # Create some temporary dirs and files (files must be ignored)
+            os.makedirs(os.path.join('abc', 'baz'))
+            os.makedirs(os.path.join('abb', 'baz'))
+            os.makedirs(os.path.join('abc', 'faz'))
+            os.makedirs(os.path.join('def', 'baz'))
+            with open('abc1', 'w') as fp1, open('def1', 'w') as fp2:
+                fp1.write('A test')
+                fp2.write('Another test')
+            # Test completions
+            self.assertEqual(c('a'), set(['abb/', 'abc/']))
+            self.assertEqual(c('ab'), set(['abc/', 'abb/']))
+            self.assertEqual(c('abc'), set(['abc/']))
+            self.assertEqual(c('abc/'), set(['abc/baz/', 'abc/faz/']))
+            self.assertEqual(c('d'), set(['def/']))
+            self.assertEqual(c('def/'), set(['def/baz/']))
+            self.assertEqual(c('e'), set([]))
+            self.assertEqual(c('def/k'), set([]))
+        return 
+    
     def test_subparsers(self):
         def make_parser():
             parser = argparse.ArgumentParser()


### PR DESCRIPTION
Hello, and congrats for the nice work. Lately, I have been using `argcomplete` more and more for my administrative Python scripts.

I sometimes came across the situation where i needed directory-only completion (e.g. like `complete -d`). I have created a completer class to address this, and i thought that it could be usefull to someone.

I did'nt use the subprocess approch that you have followed in `FilesCompleter`, because the task is quite simple and can be easily performed with plain `os.path` tools. 