### PR TITLE
Added option to avoid default readline completion

### DIFF
--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -29,11 +29,16 @@ _python_argcomplete() {
         unset COMPREPLY
     fi
 }
-complete -o nospace -o default -F _python_argcomplete "%s"
+complete %(complete_opts)s -F _python_argcomplete "%(executable)s"
 '''
 
-parser = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+
+parser.add_argument('--no-defaults', 
+    dest='use_defaults', action='store_false', default=True, 
+    help='When no matches are generated, do not fallback to readline\'s default completion')
+
 parser.add_argument("executable")
 
 if len(sys.argv)==1:
@@ -41,4 +46,8 @@ if len(sys.argv)==1:
     sys.exit(1)
 
 args = parser.parse_args()
-sys.stdout.write(shellcode % args.executable)
+
+sys.stdout.write(shellcode % dict(
+    complete_opts = '-o nospace -o default' if args.use_defaults else '-o nospace',
+    executable = args.executable
+))


### PR DESCRIPTION
The `register-python-argcomplete` scritp is hardcoding `-o default` when registering a programmable completion to Bash. In most cases, this is sane default behavior, but there exist some valid cases when this is not desirable (when no matches actually means that the completer cannot suggest anything (e.g for integer option values)).

In the past, when i wanted to workaround this, i manually replayed the `complete` part of the generated shell code. But i think that adding a option for `register-python-argcomplete` is a more clean solution.
