### PR TITLE
Add specifiable complete arguments at global activation/registration

### DIFF
--- a/scripts/activate-global-python-argcomplete
+++ b/scripts/activate-global-python-argcomplete
@@ -8,13 +8,17 @@
 Activate the generic bash-completion script for the argcomplete module.
 '''
 
-import os, sys, argparse, argcomplete, shutil
+import os, sys, argparse, argcomplete, shutil, fileinput
 
 parser = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
 
 dest_opt = parser.add_argument("--dest", help="Specify the bash completion modules directory to install into", default="/etc/bash_completion.d")
 parser.add_argument("--user", help="Install into user directory (~/.bash_completion.d/)", action='store_true')
+parser.add_argument("--no-defaults", dest="use_defaults", action="store_false", default=True,
+    help="When no matches are generated, do not fallback to readline\'s default completion")
+parser.add_argument("--complete-arguments", nargs=argparse.REMAINDER,
+    help="arguments to call complete with; use of this option discards default options")
 argcomplete.autocomplete(parser)
 args = parser.parse_args()
 
@@ -30,13 +34,36 @@ elif not os.path.exists(args.dest) and args.dest != '-':
 
 activator = os.path.join(os.path.dirname(argcomplete.__file__), 'bash_completion.d', 'python-argcomplete.sh')
 
+if args.complete_arguments is None:
+    complete_options = '-o nospace -o default -o bashdefault' if args.use_defaults else '-o nospace -o bashdefault'
+else:
+    complete_options = " ".join(args.complete_arguments)
+complete_call = "complete{} -D -F _python_argcomplete_global".format(" " + complete_options if complete_options else "")
+def replaceCompleteCall(line):
+    if line.startswith("complete") and "_python_argcomplete_global" in line:
+        return complete_call+('\n' if line.endswith('\n') else '')
+    else:
+        return line
+
 if args.dest == '-':
-    sys.stdout.write(open(activator).read())
+    for l in open(activator):
+        sys.stdout.write(replaceCompleteCall(l))
 else:
     dest = os.path.join(args.dest, "python-argcomplete.sh")
-    sys.stdout.write("Installing bash completion script " + dest + "\n")
+
+    sys.stdout.write("Installing bash completion script " + dest)
+    if not args.use_defaults:
+        sys.stdout.write(" without -o default")
+    elif args.complete_arguments:
+        sys.stdout.write(" with options: " + complete_options)
+    sys.stdout.write("\n")
+
     try:
         shutil.copy(activator, dest)
+        if not args.complete_arguments is None or not args.use_defaults:
+            for l in fileinput.input(dest, inplace=True):
+                # fileinput with inplace=True redirects stdout to the edited file
+                sys.stdout.write(replaceCompleteCall(l))
     except Exception as e:
         err = str(e)
         if args.dest == dest_opt.default:

--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -35,9 +35,11 @@ complete %(complete_opts)s -F _python_argcomplete "%(executable)s"
 parser = argparse.ArgumentParser(
     description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 
-parser.add_argument('--no-defaults', 
-    dest='use_defaults', action='store_false', default=True, 
+parser.add_argument('--no-defaults',
+    dest='use_defaults', action='store_false', default=True,
     help='When no matches are generated, do not fallback to readline\'s default completion')
+parser.add_argument('--complete-arguments', nargs=argparse.REMAINDER,
+    help='arguments to call complete with; use of this option discards default options')
 
 parser.add_argument("executable")
 
@@ -47,7 +49,12 @@ if len(sys.argv)==1:
 
 args = parser.parse_args()
 
+if args.complete_arguments is None:
+    complete_options = '-o nospace -o default' if args.use_defaults else '-o nospace'
+else:
+    complete_options = " ".join(args.complete_arguments)
+
 sys.stdout.write(shellcode % dict(
-    complete_opts = '-o nospace -o default' if args.use_defaults else '-o nospace',
+    complete_opts = complete_options,
     executable = args.executable
 ))


### PR DESCRIPTION
Makes it possible to remove defaults using global activation and no just with registration. Also enables generically customizing complete arguments. Feedback is given when non-default arguments are specified when globally activating.

The `--no-defaults` option is kept for backward compatibility and ease of use.

Changes are best seen running `activate-global-python-argcomplete --dest=-` with various options and looking at the last line in the ouput, the call to complete. e.g:
* `activate-global-python-argcomplete --dest=-`<br/>
  ↳ `complete -o nospace -o default -o bashdefault -D -F _python_argcomplete_global`
* `activate-global-python-argcomplete --dest=- --no-defaults`<br/>
  ↳ `complete -o nospace -o bashdefault -D -F _python_argcomplete_global`
* `activate-global-python-argcomplete --dest=- --complete-arguments --o nospace`<br/>
  ↳ `complete -o nospace -D -F _python_argcomplete_global`
* `activate-global-python-argcomplete --dest=- --complete-arguments`<br/>
  ↳ `complete -D -F _python_argcomplete_global`

In summary, the call to complete in `python-argcomplete.sh` is removed, and appended to the file with appropriate arguments after the file is copied. The same options are added to `register-python-argcomplete` for consistency.

Note: the difference remains that by default the register script passes neither `-D` nor `-o bashdefault` to `complete`, whereas the activate script does pass them.