### PR TITLE
Made context managers exception-safe.

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -34,16 +34,20 @@ from .my_argparse import IntrospectiveArgumentParser, action_is_satisfied, actio
 def mute_stdout():
     stdout = sys.stdout
     sys.stdout = open(os.devnull, "w")
-    yield
-    sys.stdout = stdout
+    try:
+        yield
+    finally:
+        sys.stdout = stdout
 
 @contextlib.contextmanager
 def mute_stderr():
     stderr = sys.stderr
     sys.stderr = open(os.devnull, "w")
-    yield
-    sys.stderr.close()
-    sys.stderr = stderr
+    try:
+        yield
+    finally:
+        sys.stderr.close()
+        sys.stderr = stderr
 
 class ArgcompleteException(Exception):
     pass


### PR DESCRIPTION
Context managers used to suppres stdout and stderr output were not
exception safe. When an exception occurred in wrapped code (such as
`SystemExit` from `parse_args()`) the correct file objects were not put
back. This has caused stderr to be permanently muted in several use
cases, specifically in realine-based programs.

This patch fixes the issue by following recommendations from
`contextlib` documentation, see:
https://docs.python.org/2/library/contextlib.html#contextlib.contextmanager