### PR TITLE
Fix nargs handling for optionals

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -467,6 +467,37 @@ class TestArgcomplete(unittest.TestCase):
         for cmd, output in expected_outputs:
             self.assertEqual(set(self.run_completer(make_parser(), cmd)), set(output))
 
+    def test_optional_nargs(self):
+        def make_parser():
+            parser = ArgumentParser()
+            parser.add_argument("--foo", choices=["foo1", "foo2"], nargs=2)
+            parser.add_argument("--bar", choices=["bar1", "bar2"], nargs="?")
+            parser.add_argument("--baz", choices=["baz1", "baz2"], nargs="*")
+            parser.add_argument("--qux", choices=["qux1", "qux2"], nargs="+")
+            return parser
+
+        options = ["--foo", "--bar", "--baz", "--qux", "-h", "--help"]
+
+        expected_outputs = (
+            ("prog ", options),
+
+            ("prog --foo ", ["foo1", "foo2"]),
+            ("prog --foo foo1 ", ["foo1", "foo2"]),
+            ("prog --foo foo1 foo2 ", options),
+
+            ("prog --bar ", ["bar1", "bar2"] + options),
+            ("prog --bar bar1 ", options),
+
+            ("prog --baz ", ["baz1", "baz2"] + options),
+            ("prog --baz baz1 ", ["baz1", "baz2"] + options),
+
+            ("prog --qux ", ["qux1", "qux2"]),
+            ("prog --qux qux1 ", ["qux1", "qux2"] + options),
+        )
+
+        for cmd, output in expected_outputs:
+            self.assertEqual(set(self.run_completer(make_parser(), cmd)), set(output))
+
 
 class TestArgcompleteREPL(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This fixes the handling for nargs values `N ? * +` as shown in the unit test. Some extra work is needed to make `argparse.REMAINDER` work properly.