### PR TITLE
Attempt to handle variable length positional nargs

### DIFF
--- a/argcomplete/my_argparse.py
+++ b/argcomplete/my_argparse.py
@@ -239,11 +239,9 @@ class IntrospectiveArgumentParser(ArgumentParser):
 
             # slice off the appropriate arg strings for each Positional
             # and add the Positional and its args to the list
+            for action, arg_count in zip(positionals, arg_counts):  # Added by argcomplete
+                self.active_actions.append(action)  # Added by argcomplete
             for action, arg_count in zip(positionals, arg_counts):
-                if arg_count > 0:  # Added by argcomplete
-                    self.active_actions = [action]  # Added by argcomplete
-                else:  # Added by argcomplete
-                    self.active_actions.append(action)  # Added by argcomplete
                 args = arg_strings[start_index: start_index + arg_count]
                 start_index += arg_count
                 action.num_consumed_args = len(args)   # Added by argcomplete


### PR DESCRIPTION
This is an imperfect solution that chooses to show too many completions rather than too few. Note that this somewhat blurs the meaning of `active_actions` since we have to store the whole sequence of positionals in case we need to run completers for all of them.

The problem is that you can't know in advance which arguments belong to which action. For example, one of the original tests was `"prog c bus apple " => ["-h", "--help"]`. The user intends for `apple` to fill in `value` and hence no more positional arguments can be added. However, if the user were to then type `orange`, argparse would assign both `bus` and `apple` to `var` (in this case that happens to be invalid, but it won't always be). The solution I've taken is to always complete all positionals after `var` since anything typed past that point could eventually end up as one of those arguments.

I'm not 100% sure this is the best solution, but I've put up this PR for discussion.