### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ completions like you would get in the IPython shell:
     import IPython
     parser.add_argument("--python-name").completer = IPython.core.completer.Completer()
 
-You can also use `argcomplete.CompletionFinder.rl_complete <https://argcomplete.readthedocs.org/en/latest/#argcomplete.CompletionFinder.rl_complete>`_
+You can also use `argcomplete.CompletionFinder.rl_complete <https://argcomplete.readthedocs.io/en/latest/#argcomplete.CompletionFinder.rl_complete>`_
 to plug your entire argparse parser as a readline completer.
 
 Printing warnings in completers
@@ -258,7 +258,7 @@ Inspired and informed by the optcomplete_ module by Martin Blais.
 Links
 -----
 * `Project home page (GitHub) <https://github.com/kislyuk/argcomplete>`_
-* `Documentation (Read the Docs) <https://argcomplete.readthedocs.org/en/latest/>`_
+* `Documentation (Read the Docs) <https://argcomplete.readthedocs.io/en/latest/>`_
 * `Package distribution (PyPI) <https://pypi.python.org/pypi/argcomplete>`_
 * `Change log <https://github.com/kislyuk/argcomplete/blob/master/Changes.rst>`_
 
@@ -281,4 +281,4 @@ Licensed under the terms of the `Apache License, Version 2.0 <http://www.apache.
 .. image:: https://img.shields.io/pypi/l/argcomplete.svg
         :target: https://pypi.python.org/pypi/argcomplete
 .. image:: https://readthedocs.org/projects/argcomplete/badge/?version=latest
-        :target: https://argcomplete.readthedocs.org/
+        :target: https://argcomplete.readthedocs.io/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.