### PR TITLE
Disable duplicated flags

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -608,9 +608,11 @@ class ExclusiveCompletionFinder(CompletionFinder):
     def _action_allowed(action, parser):
         class_name = ExclusiveCompletionFinder
         allowed = super(class_name, class_name)._action_allowed(action, parser)
-        exist = action not in parser._seen_non_default_actions or action._orig_class == argparse._AppendAction
 
-        return allowed and exist
+        append_classes = (argparse._AppendAction, argparse._AppendConstAction)
+        not_exist = action not in parser._seen_non_default_actions or action._orig_class in append_classes
+
+        return allowed and not_exist
 
 autocomplete = CompletionFinder()
 autocomplete.__doc__ = """ Use this to access argcomplete. See :meth:`argcomplete.CompletionFinder.__call__()`. """

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -606,13 +606,17 @@ class CompletionFinder(object):
 class ExclusiveCompletionFinder(CompletionFinder):
     @staticmethod
     def _action_allowed(action, parser):
-        class_name = ExclusiveCompletionFinder
-        allowed = super(class_name, class_name)._action_allowed(action, parser)
+        if not CompletionFinder._action_allowed(action, parser):
+            return False
 
         append_classes = (argparse._AppendAction, argparse._AppendConstAction)
-        not_exist = action not in parser._seen_non_default_actions or action._orig_class in append_classes
+        if action._orig_class in append_classes:
+            return True
+        
+        if action not in parser._seen_non_default_actions:
+            return True
 
-        return allowed and not_exist
+        return False
 
 autocomplete = CompletionFinder()
 autocomplete.__doc__ = """ Use this to access argcomplete. See :meth:`argcomplete.CompletionFinder.__call__()`. """

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -606,7 +606,7 @@ class CompletionFinder(object):
 class ExclusiveCompletionFinder(CompletionFinder):
     def _get_option_completions(self, parser, cword_prefix, parsed_args):
         super_function = super(ExclusiveCompletionFinder, self)._get_option_completions
-        option_completions = super_function(parser, cword_prefix)
+        option_completions = super_function(parser, cword_prefix, parsed_args)
 
         for action in parser._actions:
             if getattr(parsed_args, action.dest, False):

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -608,8 +608,9 @@ class ExclusiveCompletionFinder(CompletionFinder):
     def _action_allowed(action, parser):
         class_name = ExclusiveCompletionFinder
         allowed = super(class_name, class_name)._action_allowed(action, parser)
+        exist = action not in parser._seen_non_default_actions or action._orig_class == argparse._AppendAction
 
-        return allowed and action not in parser._seen_non_default_actions
+        return allowed and exist
 
 autocomplete = CompletionFinder()
 autocomplete.__doc__ = """ Use this to access argcomplete. See :meth:`argcomplete.CompletionFinder.__call__()`. """

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -612,7 +612,7 @@ class ExclusiveCompletionFinder(CompletionFinder):
         append_classes = (argparse._AppendAction, argparse._AppendConstAction)
         if action._orig_class in append_classes:
             return True
-        
+
         if action not in parser._seen_non_default_actions:
             return True
 

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -334,7 +334,7 @@ class CompletionFinder(object):
             return short_opts if short_opts else long_opts
         return []
 
-    def _get_option_completions(self, parser, cword_prefix):
+    def _get_option_completions(self, parser, cword_prefix, parsed_args):
         self._display_completions.update(
             [[" ".join(ensure_str(x) for x in action.option_strings if ensure_str(x).startswith(cword_prefix)), action.help]  # noqa
              for action in parser._actions
@@ -440,7 +440,7 @@ class CompletionFinder(object):
         active_parser = active_parsers[-1]
         debug("active_parser:", active_parser)
         if self.always_complete_options or (len(cword_prefix) > 0 and cword_prefix[0] in active_parser.prefix_chars):
-            completions += self._get_option_completions(active_parser, cword_prefix, parsed_args=parsed_args)
+            completions += self._get_option_completions(active_parser, cword_prefix, parsed_args)
         debug("optional options:", completions)
 
         next_positional = self._get_next_positional()
@@ -604,7 +604,7 @@ class CompletionFinder(object):
         return self._display_completions
 
 class ExclusiveCompletionFinder(CompletionFinder):
-    def _get_option_completions(self, parser, cword_prefix, parsed_args=None):
+    def _get_option_completions(self, parser, cword_prefix, parsed_args):
         super_function = super(ExclusiveCompletionFinder, self)._get_option_completions
         option_completions = super_function(parser, cword_prefix)
 

--- a/test/test.py
+++ b/test/test.py
@@ -675,8 +675,8 @@ class TestArgcompleteREPL(unittest.TestCase):
             ("prog ", ["--foo", "--bar", "--baz", "--no-bar"]),
             ("prog --baz ", ["baz1", "baz2"]),
             ("prog --baz baz1 ", ["--foo", "--bar", "--no-bar"]),
-            ("prog --bar  ", ["--foo", "--bar", "--baz", "--no-bar"]),
-            ("prog --foo  --no-bar ", ["--foo", "--bar", "--baz"]),
+            ("prog --bar ", ["--foo", "--bar", "--baz", "--no-bar"]),
+            ("prog --foo --no-bar ", ["--foo", "--bar", "--baz"]),
         )
 
         for cmd, output in expected_outputs:

--- a/test/test.py
+++ b/test/test.py
@@ -660,7 +660,6 @@ class TestArgcomplete(unittest.TestCase):
             ("prog ", ["--foo", "--bar", "--baz", "--no-bar"]),
             ("prog --baz ", ["baz1", "baz2"]),
             ("prog --baz baz1 ", ["--foo", "--bar", "--no-bar"]),
-            ("prog --bar ", ["bar1", "bar2"]),
             ("prog --foo --no-bar ", ["--foo", "--bar", "--baz"]),
             ("prog --foo --bar bar1 ", ["--foo", "--bar", "--baz", "--no-bar"]),
         )

--- a/test/test.py
+++ b/test/test.py
@@ -64,8 +64,9 @@ class TestArgcomplete(unittest.TestCase):
     def tearDown(self):
         os.environ = self._os_environ
 
-    def run_completer(self, parser, command, point=None, **kwargs):
+    def run_completer(self, parser, command, point=None, completer=autocomplete, **kwargs):
         command = ensure_str(command)
+        
         if point is None:
             # Adjust point for wide chars
             point = str(len(command.encode(sys_encoding)))
@@ -73,7 +74,7 @@ class TestArgcomplete(unittest.TestCase):
             os.environ["COMP_LINE"] = ensure_bytes(command) if USING_PYTHON2 else command
             os.environ["COMP_POINT"] = point
             os.environ["_ARGCOMPLETE_COMP_WORDBREAKS"] = '"\'@><=;|&(:'
-            self.assertRaises(SystemExit, autocomplete, parser, output_stream=t,
+            self.assertRaises(SystemExit, completer, parser, output_stream=t,
                               exit_method=sys.exit, **kwargs)
             t.seek(0)
             return t.read().decode(sys_encoding).split(IFS)
@@ -646,6 +647,26 @@ class TestArgcomplete(unittest.TestCase):
         self.assertEqual(self.run_completer(make_parser(), "prog "), ["bar "])
         self.assertEqual(self.run_completer(make_parser(), "prog ", append_space=False), ["bar"])
 
+    def test_exclusive_class(self):
+        parser = ArgumentParser(add_help=False)
+        parser.add_argument("--foo", dest="types", action="append_const", const=str)
+        parser.add_argument("--bar", dest="types", action="append", choices=["bar1", "bar2"])
+        parser.add_argument("--baz", choices=["baz1", "baz2"])
+        parser.add_argument("--no-bar", action="store_true")
+
+        completer = ExclusiveCompletionFinder(parser, always_complete_options=True)
+
+        expected_outputs = (
+            ("prog ", ["--foo", "--bar", "--baz", "--no-bar"]),
+            ("prog --baz ", ["baz1", "baz2"]),
+            ("prog --baz baz1 ", ["--foo", "--bar", "--no-bar"]),
+            ("prog --bar ", ["bar1", "bar2"]),
+            ("prog --foo --no-bar ", ["--foo", "--bar", "--baz"]),
+            ("prog --foo --bar bar1 ", ["--foo", "--bar", "--baz", "--no-bar"]),
+        )
+
+        for cmd, output in expected_outputs:
+            self.assertEqual(set(self.run_completer(parser, cmd, completer=completer)), set(output))
 
 class TestArgcompleteREPL(unittest.TestCase):
     def setUp(self):
@@ -661,26 +682,6 @@ class TestArgcompleteREPL(unittest.TestCase):
             comp_words, cword_prefix, cword_prequote, first_colon_pos)
 
         return completions
-
-    def test_exclusive_class(self):
-        parser = ArgumentParser(add_help=False)
-        parser.add_argument("--foo", dest="types", action="append_const", const=str)
-        parser.add_argument("--bar", dest="types", action="append_const", const=int)
-        parser.add_argument("--baz", choices=["baz1", "baz2"])
-        parser.add_argument("--no-bar", action="store_true")
-
-        completer = ExclusiveCompletionFinder(parser, always_complete_options=True)
-
-        expected_outputs = (
-            ("prog ", ["--foo", "--bar", "--baz", "--no-bar"]),
-            ("prog --baz ", ["baz1", "baz2"]),
-            ("prog --baz baz1 ", ["--foo", "--bar", "--no-bar"]),
-            ("prog --bar ", ["--foo", "--bar", "--baz", "--no-bar"]),
-            ("prog --foo --no-bar ", ["--foo", "--bar", "--baz"]),
-        )
-
-        for cmd, output in expected_outputs:
-            self.assertEqual(set(self.run_completer(parser, completer, cmd)), set(output))
 
     def test_repl_multiple_complete(self):
         p = ArgumentParser()


### PR DESCRIPTION
The autocompletion continue to offer flags that already in the command, so I added a check from parsed_args.
Not sure if it's the best way, will be glad to get more ideas on it.
