### PR TITLE
Fix parser reuse with positional arguments

### DIFF
--- a/argcomplete/my_argparse.py
+++ b/argcomplete/my_argparse.py
@@ -5,11 +5,13 @@ from argparse import ArgumentParser, ArgumentError, SUPPRESS, _SubParsersAction
 from argparse import OPTIONAL, ZERO_OR_MORE, ONE_OR_MORE, REMAINDER, PARSER
 from argparse import _get_action_name, _
 
+_num_consumed_args = {}
+
 
 def action_is_satisfied(action):
     ''' Returns False if the parse would raise an error if no more arguments are given to this action, True otherwise.
     '''
-    num_consumed_args = getattr(action, 'num_consumed_args', 0)
+    num_consumed_args = _num_consumed_args.get(action, 0)
 
     if action.nargs in [OPTIONAL, ZERO_OR_MORE, REMAINDER]:
         return True
@@ -29,7 +31,7 @@ def action_is_satisfied(action):
 def action_is_open(action):
     ''' Returns True if action could consume more arguments (i.e., its pattern is open).
     '''
-    num_consumed_args = getattr(action, 'num_consumed_args', 0)
+    num_consumed_args = _num_consumed_args.get(action, 0)
 
     if action.nargs in [ZERO_OR_MORE, ONE_OR_MORE, PARSER, REMAINDER]:
         return True
@@ -44,7 +46,7 @@ def action_is_greedy(action, isoptional=False):
     ''' Returns True if action will necessarily consume the next argument.
     isoptional indicates whether the argument is an optional (starts with -).
     '''
-    num_consumed_args = getattr(action, 'num_consumed_args', 0)
+    num_consumed_args = _num_consumed_args.get(action, 0)
 
     if action.option_strings:
         if not isoptional and not action_is_satisfied(action):
@@ -61,6 +63,7 @@ class IntrospectiveArgumentParser(ArgumentParser):
     '''
 
     def _parse_known_args(self, arg_strings, namespace):
+        _num_consumed_args.clear()  # Added by argcomplete
         self._argcomplete_namespace = namespace
         self.active_actions = []  # Added by argcomplete
         # replace arg strings that are file references
@@ -205,7 +208,7 @@ class IntrospectiveArgumentParser(ArgumentParser):
                     start = start_index + 1
                     selected_patterns = arg_strings_pattern[start:]
                     self.active_actions = [action]  # Added by argcomplete
-                    action.num_consumed_args = 0  # Added by argcomplete
+                    _num_consumed_args[action] = 0  # Added by argcomplete
                     arg_count = match_argument(action, selected_patterns)
                     stop = start + arg_count
                     args = arg_strings[start:stop]
@@ -213,7 +216,7 @@ class IntrospectiveArgumentParser(ArgumentParser):
                     # Begin added by argcomplete
                     # If the pattern is not open (e.g. no + at the end), remove the action from active actions (since
                     # it wouldn't be able to consume any more args)
-                    action.num_consumed_args = len(args)
+                    _num_consumed_args[action] = len(args)
                     if not action_is_open(action):
                         self.active_actions.remove(action)
                     # End added by argcomplete
@@ -246,7 +249,7 @@ class IntrospectiveArgumentParser(ArgumentParser):
             for action, arg_count in zip(positionals, arg_counts):
                 args = arg_strings[start_index: start_index + arg_count]
                 start_index += arg_count
-                action.num_consumed_args = len(args)   # Added by argcomplete
+                _num_consumed_args[action] = len(args)   # Added by argcomplete
                 take_action(action, args)
 
             # slice off the Positionals that we just parsed and return the

--- a/test/test.py
+++ b/test/test.py
@@ -707,7 +707,6 @@ class TestArgcompleteREPL(unittest.TestCase):
         for cmd, output in expected_outputs:
             self.assertEqual(set(self.run_completer(p, c, cmd)), set(output))
 
-    @unittest.expectedFailure
     def test_repl_reuse_parser_with_positional(self):
         p = ArgumentParser()
         p.add_argument("foo", choices=["aa", "bb", "cc"])


### PR DESCRIPTION
Minimal changes to fix the expected failure test case for reusing a parser. The problem was `num_consumed_args` was never reset on the actions. Since I don't know of an easy way to reset all the actions, I've changed this to instead store that count in a global that is reset when arguments are parsed. 

A more natural way to do this would be to attach the dictionary to the parser, but that would require making the three `action_is_*` functions be methods of `IntrospectiveArgumentParser`.