### PR TITLE
Fix parser reuse

### DIFF
--- a/argcomplete/my_argparse.py
+++ b/argcomplete/my_argparse.py
@@ -59,7 +59,6 @@ def action_is_greedy(action, isoptional=False):
 class IntrospectiveArgumentParser(ArgumentParser):
     ''' The following is a verbatim copy of ArgumentParser._parse_known_args (Python 2.7.3),
     except for the lines that contain the string "Added by argcomplete".
-    Lines that contain the string "Disabled by argcomplete" have been commented out.
     '''
 
     def _parse_known_args(self, arg_strings, namespace):
@@ -304,16 +303,14 @@ class IntrospectiveArgumentParser(ArgumentParser):
 
         if positionals:
             self.active_actions.append(positionals[0])  # Added by argcomplete
-            # self.error(_('too few arguments'))  # Disabled by argcomplete
+            self.error(_('too few arguments'))
 
-        # Begin disabled by arg complete
-        # # make sure all required actions were present
-        # for action in self._actions:
-        #     if action.required:
-        #         if action not in seen_actions:
-        #             name = _get_action_name(action)
-        #             self.error(_('argument %s is required') % name)
-        # End disabled by argcomplete
+        # make sure all required actions were present
+        for action in self._actions:
+            if action.required:
+                if action not in seen_actions:
+                    name = _get_action_name(action)
+                    self.error(_('argument %s is required') % name)
 
         # make sure all required groups had one option present
         for group in self._mutually_exclusive_groups:

--- a/test/test.py
+++ b/test/test.py
@@ -684,6 +684,24 @@ class TestArgcompleteREPL(unittest.TestCase):
         with self.assertRaises(SystemExit):
             p.parse_args(["--foo", "spam"])
 
+    @unittest.expectedFailure
+    def test_repl_subparser_parse_after_complete(self):
+        p = ArgumentParser()
+        sp = p.add_subparsers().add_parser("foo")
+        sp.add_argument("bar", choices=["bar"])
+
+        c = CompletionFinder(p, always_complete_options=True)
+
+        completions = self.run_completer(p, c, "prog foo ")
+        assert(set(completions) == set(["-h", "--help", "bar"]))
+
+        args = p.parse_args(["foo", "bar"])
+        assert(args.bar == "bar")
+
+        # "bar" is required - check the parser still enforces this.
+        with self.assertRaises(SystemExit):
+            p.parse_args(["foo"])
+
     def test_repl_subcommand(self):
         p = ArgumentParser()
         p.add_argument("--foo")

--- a/test/test.py
+++ b/test/test.py
@@ -665,10 +665,9 @@ class TestArgcompleteREPL(unittest.TestCase):
         completions = self.run_completer(p, c, "prog --")
         assert(set(completions) == set(["--help", "--foo", "--bar"]))
 
-    @unittest.expectedFailure
     def test_repl_parse_after_complete(self):
         p = ArgumentParser()
-        p.add_argument("--foo")
+        p.add_argument("--foo", required=True)
         p.add_argument("bar", choices=["bar"])
 
         c = CompletionFinder(p, always_complete_options=True)
@@ -680,11 +679,12 @@ class TestArgcompleteREPL(unittest.TestCase):
         assert(args.foo == "spam")
         assert(args.bar == "bar")
 
-        # "bar" is required - check the parser still enforces this.
+        # Both options are required - check the parser still enforces this.
         with self.assertRaises(SystemExit):
             p.parse_args(["--foo", "spam"])
+        with self.assertRaises(SystemExit):
+            p.parse_args(["bar"])
 
-    @unittest.expectedFailure
     def test_repl_subparser_parse_after_complete(self):
         p = ArgumentParser()
         sp = p.add_subparsers().add_parser("foo")

--- a/test/test.py
+++ b/test/test.py
@@ -647,8 +647,6 @@ class TestArgcompleteREPL(unittest.TestCase):
     def run_completer(self, parser, completer, command, point=None, **kwargs):
         cword_prequote, cword_prefix, cword_suffix, comp_words, first_colon_pos = split_line(command)
 
-        comp_words.insert(0, sys.argv[0])
-
         completions = completer._get_completions(
             comp_words, cword_prefix, cword_prequote, first_colon_pos)
 
@@ -701,12 +699,12 @@ class TestArgcompleteREPL(unittest.TestCase):
         c = CompletionFinder(p, always_complete_options=True)
 
         expected_outputs = (
-            ("", ["-h", "--help", "--foo", "--bar", "list", "show", "set"]),
-            ("li", ["list "]),
-            ("s", ["show", "set"]),
-            ("show ", ["--test", "depth", "-h", "--help"]),
-            ("show d", ["depth "]),
-            ("show depth ", ["-h", "--help"]),
+            ("prog ", ["-h", "--help", "--foo", "--bar", "list", "show", "set"]),
+            ("prog li", ["list "]),
+            ("prog s", ["show", "set"]),
+            ("prog show ", ["--test", "depth", "-h", "--help"]),
+            ("prog show d", ["depth "]),
+            ("prog show depth ", ["-h", "--help"]),
         )
 
         for cmd, output in expected_outputs:
@@ -719,13 +717,13 @@ class TestArgcompleteREPL(unittest.TestCase):
 
         c = CompletionFinder(p, always_complete_options=True)
 
-        self.assertEqual(set(self.run_completer(p, c, "")),
+        self.assertEqual(set(self.run_completer(p, c, "prog ")),
                          set(["-h", "--help", "aa", "bb", "cc"]))
 
-        self.assertEqual(set(self.run_completer(p, c, "aa ")),
+        self.assertEqual(set(self.run_completer(p, c, "prog aa ")),
                          set(["-h", "--help", "d", "e"]))
 
-        self.assertEqual(set(self.run_completer(p, c, "")),
+        self.assertEqual(set(self.run_completer(p, c, "prog ")),
                          set(["-h", "--help", "aa", "bb", "cc"]))
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -665,18 +665,24 @@ class TestArgcompleteREPL(unittest.TestCase):
         completions = self.run_completer(p, c, "prog --")
         assert(set(completions) == set(["--help", "--foo", "--bar"]))
 
+    @unittest.expectedFailure
     def test_repl_parse_after_complete(self):
         p = ArgumentParser()
         p.add_argument("--foo")
-        p.add_argument("--bar")
+        p.add_argument("bar", choices=["bar"])
 
         c = CompletionFinder(p, always_complete_options=True)
 
         completions = self.run_completer(p, c, "prog ")
-        assert(set(completions) == set(["-h", "--help", "--foo", "--bar"]))
+        assert(set(completions) == set(["-h", "--help", "--foo", "bar"]))
 
-        args = p.parse_args(["--foo", "spam"])
+        args = p.parse_args(["--foo", "spam", "bar"])
         assert(args.foo == "spam")
+        assert(args.bar == "bar")
+
+        # "bar" is required - check the parser still enforces this.
+        with self.assertRaises(SystemExit):
+            p.parse_args(["--foo", "spam"])
 
     def test_repl_subcommand(self):
         p = ArgumentParser()


### PR DESCRIPTION
In a REPL environment, parsers and subparsers continued to use the patched `_parse_known_args` method forever. This adds a similar check to the one already present in `IntrospectAction` to fall back to the base implementation when not completing.