### PR TITLE
Don't insert leading quote char

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -511,7 +511,7 @@ class CompletionFinder(object):
             if char not in comp_wordbreaks:
                 comp_wordbreaks += char
 
-        # If the word under the cursor was quoted, escape the quote char and add the leading quote back in.
+        # If the word under the cursor was quoted, escape the quote char.
         # Otherwise, escape all COMP_WORDBREAKS chars.
         if cword_prequote == "":
             # Bash mangles completions which contain colons if COMP_WORDBREAKS contains a colon.
@@ -525,7 +525,7 @@ class CompletionFinder(object):
             if cword_prequote == '"':
                 for char in "`$!":
                     completions = [c.replace(char, "\\" + char) for c in completions]
-            completions = [cword_prequote + c.replace(cword_prequote, "\\" + cword_prequote) for c in completions]
+            completions = [c.replace(cword_prequote, "\\" + cword_prequote) for c in completions]
 
         # Note: similar functionality in bash is turned off by supplying the "-o nospace" option to complete.
         # We can't use that functionality because bash is not smart enough to recognize continuation characters (/) for

--- a/test/test.py
+++ b/test/test.py
@@ -202,11 +202,11 @@ class TestArgcomplete(unittest.TestCase):
 
         expected_outputs = (
             ("prog --url ", ["http\\://url1", "http\\://url2"]),
-            ("prog --url \"", ['"http://url1', '"http://url2']),
+            ("prog --url \"", ['http://url1', 'http://url2']),
             ("prog --url \"http://url1\" --email ", ["a\\@b.c", "a\\@b.d", "ab\\@c.d", "bcd\\@e.f", "bce\\@f.g"]),
             ("prog --url \"http://url1\" --email a", ["a\\@b.c", "a\\@b.d", "ab\\@c.d"]),
-            ("prog --url \"http://url1\" --email \"a@", ['"a@b.c', '"a@b.d']),
-            ("prog --url \"http://url1\" --email \"a@b.c\" \"a@b.d\" \"a@", ['"a@b.c', '"a@b.d']),
+            ("prog --url \"http://url1\" --email \"a@", ['a@b.c', 'a@b.d']),
+            ("prog --url \"http://url1\" --email \"a@b.c\" \"a@b.d\" \"a@", ['a@b.c', 'a@b.d']),
             ("prog --url \"http://url1\" --email \"a@b.c\" \"a@b.d\" \"ab@c.d\" ", ["--url", "--email", "-h", "--help"]),
         )
 
@@ -314,7 +314,7 @@ class TestArgcomplete(unittest.TestCase):
             ("prog --age 1 eggs", ["eggs "]),
             ("prog --age 2 eggs ", ["on a train", "with a goat", "on a boat", "in the rain", "--help", "-h"]),
             ("prog eggs ", ["on a train", "with a goat", "on a boat", "in the rain", "--help", "-h"]),
-            ("prog eggs \"on a", ['\"on a train', '\"on a boat']),
+            ("prog eggs \"on a", ['on a train', 'on a boat']),
             ("prog eggs on\\ a", ["on a train", "on a boat"]),
             ("prog spam ", ["iberico", "ham", "--help", "-h"]),
         )


### PR DESCRIPTION
Bash doesn't appear to need this; it only clutters up the completion display.