### PR TITLE
scripts: add support for tcsh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,18 @@ Shellcode (only necessary if global completion is not activated - see `Global co
 
     eval "$(register-python-argcomplete my-awesome-script.py)"
 
+Tcsh Support
+------------
+To activate completions for tcsh use::
+
+    eval `register-python-argcomplete --shell tcsh my-awesome-script.py`
+
+The ``python-argcomplete-tcsh`` script provides completions for tcsh.
+The following is an example of the tcsh completion syntax for
+``my-awesome-script.py`` emitted by ``register-python-argcomplete``::
+
+    complete my-awesome-script.py 'p@*@`python-argcomplete-tcsh my-awesome-script.py`@'
+
 argcomplete.autocomplete(*parser*)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This method is the entry point to the module. It must be called **after** ArgumentParser construction is complete, but

--- a/scripts/python-argcomplete-tcsh
+++ b/scripts/python-argcomplete-tcsh
@@ -1,0 +1,17 @@
+#!/bin/sh
+IFS=
+export IFS
+
+COMP_WORDBREAKS=
+export COMP_WORDBREAKS
+
+COMP_LINE=${COMMAND_LINE}
+export COMP_LINE
+
+COMP_POINT=${#COMMAND_LINE}
+export COMP_POINT
+
+_ARGCOMPLETE=1
+export _ARGCOMPLETE
+
+"$1" 8>&1 9>&2 1>/dev/null 2>/dev/null

--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -12,6 +12,10 @@ To perform the registration, source the output of this script in your bash shell
 Example:
 
     $ eval "$(register-python-argcomplete my-favorite-script.py)"
+
+For Tcsh
+
+    $ eval `register-python-argcomplete --shell tcsh my-favorite-script.py`
 '''
 
 import sys
@@ -33,6 +37,10 @@ _python_argcomplete() {
 complete %(complete_opts)s -F _python_argcomplete "%(executable)s"
 '''
 
+tcshcode = '''\
+complete "%(executable)s" 'p@*@`python-argcomplete-tcsh "%(executable)s"`@'
+'''
+
 parser = argparse.ArgumentParser(
     description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 
@@ -44,6 +52,10 @@ parser.add_argument(
     '--complete-arguments',
     nargs=argparse.REMAINDER,
     help='arguments to call complete with; use of this option discards default options')
+parser.add_argument(
+    '-s', '--shell',
+    choices=('bash', 'tcsh'), default='bash',
+    help='output code for the specified shell')
 
 parser.add_argument("executable")
 
@@ -58,7 +70,12 @@ if args.complete_arguments is None:
 else:
     complete_options = " ".join(args.complete_arguments)
 
-sys.stdout.write(shellcode % dict(
+if args.shell == 'bash':
+    code = shellcode
+else:
+    code = tcshcode
+
+sys.stdout.write(code % dict(
     complete_opts=complete_options,
     executable=args.executable
 ))


### PR DESCRIPTION
Teach register-python-argcomplete to support tcsh.
Add a python-argcomplete-tcsh script for use with tcsh and
document the new feature.

Closes #49
Signed-off-by: David Aguilar <davvid@gmail.com>