### PR TITLE
Expose COMP_TYPE environment variable

### DIFF
--- a/argcomplete/bash_completion.d/python-argcomplete.sh
+++ b/argcomplete/bash_completion.d/python-argcomplete.sh
@@ -40,6 +40,7 @@ _python_argcomplete_global() {
         COMPREPLY=( $(_ARGCOMPLETE_IFS="$IFS" \
             COMP_LINE="$COMP_LINE" \
             COMP_POINT="$COMP_POINT" \
+            COMP_TYPE="$COMP_TYPE" \
             _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
             _ARGCOMPLETE=$ARGCOMPLETE \
             "$executable" 8>&1 9>&2 1>/dev/null 2>&1) )

--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -27,6 +27,7 @@ _python_argcomplete() {
     COMPREPLY=( $(IFS="$IFS" \
                   COMP_LINE="$COMP_LINE" \
                   COMP_POINT="$COMP_POINT" \
+                  COMP_TYPE="$COMP_TYPE" \
                   _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
                   _ARGCOMPLETE=1 \
                   "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )

--- a/test/prog
+++ b/test/prog
@@ -2,9 +2,11 @@
 """Test script used by test.TestBash."""
 import argparse
 import argcomplete
+import os
 
 
 def complete_cont(*args, **kwargs):
+    assert 'COMP_TYPE' in os.environ
     return ['foo=', 'bar/', 'baz:']
 
 


### PR DESCRIPTION
Resolves #156 

Tested both `python-argcomplete.sh` and `register-python-argcomplete` on Ubuntu 16.04 with:
`GNU bash, version 4.3.46(1)-release (x86_64-pc-linux-gnu)`

The first tab completion passes: `COMP_TYPE=9`
The second tab completion passes: `COMP_TYPE=63`