### PR TITLE
Only use compopt when it is supported

### DIFF
--- a/argcomplete/bash_completion.d/python-argcomplete.sh
+++ b/argcomplete/bash_completion.d/python-argcomplete.sh
@@ -37,17 +37,19 @@ _python_argcomplete_global() {
 
     if [[ $ARGCOMPLETE == 1 ]] || [[ $ARGCOMPLETE == 2 ]]; then
         local IFS=$(echo -e '\v')
+        compopt +o nospace 2> /dev/null
+        local SUPPRESS_SPACE=$?
         COMPREPLY=( $(_ARGCOMPLETE_IFS="$IFS" \
             COMP_LINE="$COMP_LINE" \
             COMP_POINT="$COMP_POINT" \
             COMP_TYPE="$COMP_TYPE" \
             _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
             _ARGCOMPLETE=$ARGCOMPLETE \
-            _ARGCOMPLETE_SUPPRESS_SPACE=1 \
+            _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
             "$executable" 8>&1 9>&2 1>/dev/null 2>&1) )
         if [[ $? != 0 ]]; then
             unset COMPREPLY
-        elif [[ "$COMPREPLY" =~ [=/:]$ ]]; then
+        elif [[ $SUPPRESS_SPACE == 0 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
             compopt -o nospace
         fi
     else

--- a/scripts/activate-global-python-argcomplete
+++ b/scripts/activate-global-python-argcomplete
@@ -39,7 +39,7 @@ elif not os.path.exists(args.dest) and args.dest != '-':
 activator = os.path.join(os.path.dirname(argcomplete.__file__), 'bash_completion.d', 'python-argcomplete.sh')
 
 if args.complete_arguments is None:
-    complete_options = '-o default -o bashdefault' if args.use_defaults else '-o bashdefault'
+    complete_options = '-o nospace -o default -o bashdefault' if args.use_defaults else '-o nospace -o bashdefault'
 else:
     complete_options = " ".join(args.complete_arguments)
 complete_call = "complete{} -D -F _python_argcomplete_global".format(" " + complete_options if complete_options else "")

--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -21,20 +21,22 @@ For Tcsh
 import sys
 import argparse
 
-shellcode = '''
+shellcode = r'''
 _python_argcomplete() {
-    local IFS='\013'
+    local IFS=$'\013'
+    compopt +o nospace 2> /dev/null
+    local SUPPRESS_SPACE=$?
     COMPREPLY=( $(IFS="$IFS" \
                   COMP_LINE="$COMP_LINE" \
                   COMP_POINT="$COMP_POINT" \
                   COMP_TYPE="$COMP_TYPE" \
                   _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
                   _ARGCOMPLETE=1 \
-                  _ARGCOMPLETE_SUPPRESS_SPACE=1 \
+                  _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
                   "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
     if [[ $? != 0 ]]; then
         unset COMPREPLY
-    elif [[ "$COMPREPLY" =~ [=/:]$ ]]; then
+    elif [[ $SUPPRESS_SPACE == 0 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
         compopt -o nospace
     fi
 }
@@ -70,7 +72,7 @@ if len(sys.argv) == 1:
 args = parser.parse_args()
 
 if args.complete_arguments is None:
-    complete_options = '-o default' if args.use_defaults else '-o nospace'
+    complete_options = '-o nospace -o default' if args.use_defaults else '-o nospace'
 else:
     complete_options = " ".join(args.complete_arguments)
 

--- a/test/test.py
+++ b/test/test.py
@@ -845,7 +845,6 @@ class _TestSh(object):
     def test_quoted_space(self):
         self.assertEqual(self.sh.run_command('prog space "f\t'), 'foo bar\r\n')
 
-    @unittest.skipIf(BASH_MAJOR_VERSION < 4, 'compopt not supported')
     def test_continuation(self):
         # This produces 'prog basic foo --', and '--' is ignored.
         self.assertEqual(self.sh.run_command('prog basic f\t--'), 'foo\r\n')
@@ -903,6 +902,9 @@ class TestBash(_TestSh, unittest.TestCase):
         'test_exclamation_in_double_quotes',
         'test_single_quotes_in_single_quotes',
     ]
+    if BASH_MAJOR_VERSION < 4:
+        # This requires compopt which is not available in 3.x.
+        expected_failures.append('test_quoted_exact')
 
     install_cmd = 'eval "$(register-python-argcomplete prog)"'
 


### PR DESCRIPTION
Reverts changes to `complete_options` in #159, fixes #181.