### PR TITLE
Fix additional trailing space in exact matches

### DIFF
--- a/argcomplete/bash_completion.d/python-argcomplete.sh
+++ b/argcomplete/bash_completion.d/python-argcomplete.sh
@@ -37,8 +37,10 @@ _python_argcomplete_global() {
 
     if [[ $ARGCOMPLETE == 1 ]] || [[ $ARGCOMPLETE == 2 ]]; then
         local IFS=$(echo -e '\v')
-        compopt +o nospace 2> /dev/null
-        local SUPPRESS_SPACE=$?
+        local SUPPRESS_SPACE=0
+        if compopt +o nospace 2> /dev/null; then
+            SUPPRESS_SPACE=1
+        fi
         COMPREPLY=( $(_ARGCOMPLETE_IFS="$IFS" \
             COMP_LINE="$COMP_LINE" \
             COMP_POINT="$COMP_POINT" \
@@ -49,7 +51,7 @@ _python_argcomplete_global() {
             "$executable" 8>&1 9>&2 1>/dev/null 2>&1) )
         if [[ $? != 0 ]]; then
             unset COMPREPLY
-        elif [[ $SUPPRESS_SPACE == 0 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
+        elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
             compopt -o nospace
         fi
     else

--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -24,8 +24,10 @@ import argparse
 shellcode = r'''
 _python_argcomplete() {
     local IFS=$'\013'
-    compopt +o nospace 2> /dev/null
-    local SUPPRESS_SPACE=$?
+    local SUPPRESS_SPACE=0
+    if compopt +o nospace 2> /dev/null; then
+        SUPPRESS_SPACE=1
+    fi
     COMPREPLY=( $(IFS="$IFS" \
                   COMP_LINE="$COMP_LINE" \
                   COMP_POINT="$COMP_POINT" \
@@ -36,7 +38,7 @@ _python_argcomplete() {
                   "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
     if [[ $? != 0 ]]; then
         unset COMPREPLY
-    elif [[ $SUPPRESS_SPACE == 0 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
+    elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
         compopt -o nospace
     fi
 }

--- a/test/test.py
+++ b/test/test.py
@@ -918,6 +918,12 @@ class TestBash(_TestSh, unittest.TestCase):
         self.assertEqual(output, '')
         self.sh = sh
 
+    def test_one_space_after_exact(self):
+        """Test exactly one space is appended after an exact match."""
+        # Actual command run is 'echo "prog basic foo "'.
+        result = self.sh.run_command('prog basic f\t"\1echo "')
+        self.assertEqual(result, 'prog basic foo \r\n')
+
 
 @unittest.skipIf(BASH_MAJOR_VERSION < 4, 'complete -D not supported')
 class TestBashGlobal(TestBash):


### PR DESCRIPTION
Fixes my mistake in #182 which led to an extra space being appended after exact matches.