### PR TITLE
add SuppressCompleter to skip completion for specific arguments while allowing help text

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -348,7 +348,7 @@ class CompletionFinder(object):
         for action in parser._actions:
             if not self.print_suppressed:
                 completer = getattr(action, "completer", None)
-                if isinstance(completer, SuppressCompleter):
+                if isinstance(completer, SuppressCompleter) and completer.suppress():
                     continue
                 if action.help == argparse.SUPPRESS:
                     continue

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os, sys, argparse, contextlib
 from . import completers, my_shlex as shlex
 from .compat import USING_PYTHON2, str, sys_encoding, ensure_str, ensure_bytes
-from .completers import FilesCompleter
+from .completers import FilesCompleter, SuppressCompleter
 from .my_argparse import IntrospectiveArgumentParser, action_is_satisfied, action_is_open, action_is_greedy
 
 _DEBUG = "_ARC_DEBUG" in os.environ
@@ -346,8 +346,12 @@ class CompletionFinder(object):
 
         option_completions = []
         for action in parser._actions:
-            if action.help == argparse.SUPPRESS and not self.print_suppressed:
-                continue
+            if not self.print_suppressed:
+                completer = getattr(action, "completer", None)
+                if isinstance(completer, SuppressCompleter):
+                    continue
+                if action.help == argparse.SUPPRESS:
+                    continue
             if not self._action_allowed(action, parser):
                 continue
             if not isinstance(action, argparse._SubParsersAction):

--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -92,3 +92,7 @@ class _FilteredFilesCompleter(object):
 class DirectoriesCompleter(_FilteredFilesCompleter):
     def __init__(self):
         _FilteredFilesCompleter.__init__(self, predicate=os.path.isdir)
+
+class SuppressCompleter(object):
+    def __init__(self):
+        pass

--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -96,3 +96,9 @@ class DirectoriesCompleter(_FilteredFilesCompleter):
 class SuppressCompleter(object):
     def __init__(self):
         pass
+
+    def suppress(self):
+        """
+        Decide if the completion should be suppressed
+        """
+        return True

--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -94,6 +94,10 @@ class DirectoriesCompleter(_FilteredFilesCompleter):
         _FilteredFilesCompleter.__init__(self, predicate=os.path.isdir)
 
 class SuppressCompleter(object):
+    """
+    A completer used to suppress the completion of specific arguments
+    """
+
     def __init__(self):
         pass
 

--- a/test/test.py
+++ b/test/test.py
@@ -135,7 +135,29 @@ class TestArgcomplete(unittest.TestCase):
             parser = ArgumentParser()
             parser.add_argument("--foo")
             parser.add_argument("--bar", help=SUPPRESS)
-            arg = parser.add_argument("--baz")
+            return parser
+
+        expected_outputs = (
+            ("prog ", ["--foo", "-h", "--help"]),
+            ("prog --b", [""])
+        )
+
+        for cmd, output in expected_outputs:
+            self.assertEqual(set(self.run_completer(make_parser(), cmd)), set(output))
+
+        expected_outputs = (
+            ("prog ", ["--foo", "--bar", "-h", "--help"]),
+            ("prog --b", ["--bar "])
+        )
+
+        for cmd, output in expected_outputs:
+            self.assertEqual(set(self.run_completer(make_parser(), cmd, print_suppressed=True)), set(output))
+
+    def test_suppress_completer(self):
+        def make_parser():
+            parser = ArgumentParser()
+            parser.add_argument("--foo")
+            arg = parser.add_argument("--bar")
             arg.completer = SuppressCompleter()
             return parser
 
@@ -148,8 +170,8 @@ class TestArgcomplete(unittest.TestCase):
             self.assertEqual(set(self.run_completer(make_parser(), cmd)), set(output))
 
         expected_outputs = (
-            ("prog ", ["--foo", "--bar", "--baz", "-h", "--help"]),
-            ("prog --b", ["--bar", "--baz"])
+            ("prog ", ["--foo", "--bar", "-h", "--help"]),
+            ("prog --b", ["--bar "])
         )
 
         for cmd, output in expected_outputs:

--- a/test/test.py
+++ b/test/test.py
@@ -19,7 +19,7 @@ from argcomplete import (
     ExclusiveCompletionFinder,
     _check_module
 )
-from argcomplete.completers import FilesCompleter, DirectoriesCompleter
+from argcomplete.completers import FilesCompleter, DirectoriesCompleter, SuppressCompleter
 from argcomplete.compat import USING_PYTHON2, str, sys_encoding, ensure_str, ensure_bytes
 
 IFS = "\013"
@@ -135,6 +135,8 @@ class TestArgcomplete(unittest.TestCase):
             parser = ArgumentParser()
             parser.add_argument("--foo")
             parser.add_argument("--bar", help=SUPPRESS)
+            arg = parser.add_argument("--baz")
+            arg.completer = SuppressCompleter()
             return parser
 
         expected_outputs = (
@@ -146,8 +148,8 @@ class TestArgcomplete(unittest.TestCase):
             self.assertEqual(set(self.run_completer(make_parser(), cmd)), set(output))
 
         expected_outputs = (
-            ("prog ", ["--foo", "--bar", "-h", "--help"]),
-            ("prog --b", ["--bar "])
+            ("prog ", ["--foo", "--bar", "--baz", "-h", "--help"]),
+            ("prog --b", ["--bar", "--baz"])
         )
 
         for cmd, output in expected_outputs:


### PR DESCRIPTION
Fixes #223.

The first commit adds the `SuppressCompleter` as described in the feature request.

The second commit adds a method to it which makes the actual decision if the completion should be suppressed. The default implementation is to suppress the completion. But it allows to override the decision making in a subclass and use whatever reasoning to decide to show or suppress the completion.