### PR TITLE
Register completion for multiple commands

### DIFF
--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -41,6 +41,7 @@ parser.add_argument(
 
 parser.add_argument(
     'executable',
+    nargs='+',
     help='executable to completed (when invoked by exactly this name)')
 
 if len(sys.argv) == 1:

--- a/test/test.py
+++ b/test/test.py
@@ -740,17 +740,17 @@ class TestArgcomplete(unittest.TestCase):
 
     def test_shellcode_utility(self):
         with NamedTemporaryFile() as fh:
-            sc = shellcode("prog", use_defaults=True, shell="bash", complete_arguments=None)
+            sc = shellcode(["prog"], use_defaults=True, shell="bash", complete_arguments=None)
             fh.write(sc.encode())
             fh.flush()
             subprocess.check_call(['bash', '-n', fh.name])
         with NamedTemporaryFile() as fh:
-            sc = shellcode("prog", use_defaults=False, shell="bash", complete_arguments=["-o", "nospace"])
+            sc = shellcode(["prog", "prog2"], use_defaults=False, shell="bash", complete_arguments=["-o", "nospace"])
             fh.write(sc.encode())
             fh.flush()
             subprocess.check_call(['bash', '-n', fh.name])
-        sc = shellcode("prog", use_defaults=False, shell="tcsh", complete_arguments=["-o", "nospace"])
-        sc = shellcode("prog", use_defaults=False, shell="woosh", complete_arguments=["-o", "nospace"])
+        sc = shellcode(["prog"], use_defaults=False, shell="tcsh", complete_arguments=["-o", "nospace"])
+        sc = shellcode(["prog"], use_defaults=False, shell="woosh", complete_arguments=["-o", "nospace"])
 
 class TestArgcompleteREPL(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Shell startup files may contain lots of 'register-python-argcomplete'
calls, for as many scripts as require it.

However, this can have a significant impact on shell startup time,
because each one requires starting a Python interpreter and invoking
'complete'.

Optimise this by allowing 'register-python-argcomplete' to accept
multiple commands. In Bash, the whole list of completable commands
can be passed to a single 'complete' call. Tcsh requires a separate
'complete' call for each command, but we can at least avoid the
overhead of starting Python each time.

On my machine, the time to register ~10 completed scripts decreases
from about 0.4s to 0.05s with this change.