### PR TITLE
Get rid of non-standard streams (FD 8 and 9)

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -180,9 +180,9 @@ class CompletionFinder(object):
         # print result of argcomplete to original streams
         # they will print to stdout/stderr even if sys.stdout/sys.stderr were redirected to devnull
         global debug_stream
-        debug_stream = sys.__stderr__
+        debug_stream = os.fdopen(2, "w")
         if output_stream is None:
-            output_stream = sys.__stdout__
+            output_stream = os.fdopen(1, "wb")
 
         # print("", stream=debug_stream)
         # for v in "COMP_CWORD COMP_LINE COMP_POINT COMP_TYPE COMP_KEY _ARGCOMPLETE_COMP_WORDBREAKS COMP_WORDS".split():
@@ -217,7 +217,8 @@ class CompletionFinder(object):
         completions = self._get_completions(comp_words, cword_prefix, cword_prequote, last_wordbreak_pos)
 
         debug("\nReturning completions:", completions)
-        output_stream.write(ifs.join(completions))
+        if TypeError:
+        output_stream.write(ifs.join(completions).encode(sys_encoding))
         output_stream.flush()
         debug_stream.flush()
         exit_method(0)

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -177,18 +177,12 @@ class CompletionFinder(object):
             # not an argument completion invocation
             return
 
+        # print result of argcomplete to original streams
+        # they will print to stdout/stderr even if sys.stdout/sys.stderr were redirected to devnull
         global debug_stream
-        try:
-            debug_stream = os.fdopen(9, "w")
-        except:
-            debug_stream = sys.stderr
-
+        debug_stream = sys.__stderr__
         if output_stream is None:
-            try:
-                output_stream = os.fdopen(8, "wb")
-            except:
-                debug("Unable to open fd 8 for writing, quitting")
-                exit_method(1)
+            output_stream = sys.__stdout__
 
         # print("", stream=debug_stream)
         # for v in "COMP_CWORD COMP_LINE COMP_POINT COMP_TYPE COMP_KEY _ARGCOMPLETE_COMP_WORDBREAKS COMP_WORDS".split():
@@ -223,7 +217,7 @@ class CompletionFinder(object):
         completions = self._get_completions(comp_words, cword_prefix, cword_prequote, last_wordbreak_pos)
 
         debug("\nReturning completions:", completions)
-        output_stream.write(ifs.join(completions).encode(sys_encoding))
+        output_stream.write(ifs.join(completions))
         output_stream.flush()
         debug_stream.flush()
         exit_method(0)

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -180,7 +180,7 @@ class CompletionFinder(object):
         # print result of argcomplete to original streams
         # they will print to stdout/stderr even if sys.stdout/sys.stderr were redirected to devnull
         global debug_stream
-        debug_stream = os.fdopen(2, "w")
+        debug_stream = sys.__stderr__
         if output_stream is None:
             output_stream = os.fdopen(1, "wb")
 

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -217,7 +217,6 @@ class CompletionFinder(object):
         completions = self._get_completions(comp_words, cword_prefix, cword_prequote, last_wordbreak_pos)
 
         debug("\nReturning completions:", completions)
-        if TypeError:
         output_stream.write(ifs.join(completions).encode(sys_encoding))
         output_stream.flush()
         debug_stream.flush()

--- a/argcomplete/_suppressStdOutErr.py
+++ b/argcomplete/_suppressStdOutErr.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+_DEBUG = "_ARC_DEBUG" in os.environ
+
+def main():
+    pyScript = sys.argv[1]
+    with open(pyScript) as f:
+        # check if required marker is present
+        head = f.read(1024)
+        f.seek(0)
+        if 'PYTHON_ARGCOMPLETE_OK' not in head:
+            raise Exception('marker not found')
+        else:
+            # redirect stdout and stderr to devnull if we are not debugging
+            if not _DEBUG:
+                sys.stdout = open(os.devnull, 'w')
+            sys.stderr = sys.stdout
+            exec(f.read())
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Preface
First of all, thank you for this handy module.
However, I struggled a lot to get it working on Cygwin.
I traced back the issue to the non-standard stream (File descriptor 8), that cannot be opened:
https://github.com/kislyuk/argcomplete/blob/30ff207e9a89bc08b9cb38cbeb21147ef0c23480/argcomplete/__init__.py#L186-L191
### Changes
When this PR is meged it will:
- Get rid of the non-standard streams (FD 8 and 9).
- The stdout and stderr will be suppressed by the new `_suppressStdOutErr.py` wrapper.
### Additional Notes
- Tested global completion with Bash on CYGWIN_NT-6.3 and Debian GNU/Linux 9.