### PR TITLE
Get rid of non-standard streams (FD 8 and 9)

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -12,7 +12,16 @@ from .shellintegration import shellcode
 
 _DEBUG = "_ARC_DEBUG" in os.environ
 
-debug_stream = sys.stderr
+debug_stream = sys.__stderr__
+
+# mute print function if _ARGCOMPLETE is defined and _DEBUG undefined
+# debug_stream and output_stream_default, however, are not muted
+if "_ARGCOMPLETE" in os.environ:
+    if _DEBUG:
+        sys.stdout = sys.stderr
+    else:
+        sys.stderr = None
+        sys.stdout = None
 
 def debug(*args):
     if _DEBUG:
@@ -178,17 +187,10 @@ class CompletionFinder(object):
             return
 
         global debug_stream
-        try:
-            debug_stream = os.fdopen(9, "w")
-        except:
-            debug_stream = sys.stderr
+        debug_stream = sys.__stderr__
 
         if output_stream is None:
-            try:
-                output_stream = os.fdopen(8, "wb")
-            except:
-                debug("Unable to open fd 8 for writing, quitting")
-                exit_method(1)
+            output_stream = os.fdopen(1, "wb")
 
         # print("", stream=debug_stream)
         # for v in "COMP_CWORD COMP_LINE COMP_POINT COMP_TYPE COMP_KEY _ARGCOMPLETE_COMP_WORDBREAKS COMP_WORDS".split():

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -17,11 +17,9 @@ debug_stream = sys.__stderr__
 # mute print function if _ARGCOMPLETE is defined and _DEBUG undefined
 # debug_stream and output_stream_default, however, are not muted
 if "_ARGCOMPLETE" in os.environ:
-    if _DEBUG:
-        sys.stdout = sys.stderr
-    else:
-        sys.stderr = None
-        sys.stdout = None
+    if not _DEBUG:
+        sys.stderr = open(os.devnull, "w")
+    sys.stdout = sys.stderr
 
 def debug(*args):
     if _DEBUG:

--- a/argcomplete/bash_completion.d/python-argcomplete.sh
+++ b/argcomplete/bash_completion.d/python-argcomplete.sh
@@ -12,14 +12,9 @@ __python_argcomplete_expand_tilde_by_ref () {
     fi
 }
 
-# Run something, muting output or redirecting it to the debug stream
-# depending on the value of _ARC_DEBUG.
+# Run something
 __python_argcomplete_run() {
-    if [[ -z "$_ARC_DEBUG" ]]; then
-        "$@" 8>&1 9>&2 1>/dev/null 2>&1
-    else
-        "$@" 8>&1 9>&2 1>&9 2>&1
-    fi
+    "$@"
 }
 
 _python_argcomplete_global() {

--- a/argcomplete/shellintegration.py
+++ b/argcomplete/shellintegration.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
 
 bashcode = r'''
-# Run something, muting output or redirecting it to the debug stream
-# depending on the value of _ARC_DEBUG.
+# Run something
 __python_argcomplete_run() {
-    if [[ -z "$_ARC_DEBUG" ]]; then
-        "$@" 8>&1 9>&2 1>/dev/null 2>&1
-    else
-        "$@" 8>&1 9>&2 1>&9 2>&1
-    fi
+    "$@"
 }
 
 _python_argcomplete() {

--- a/scripts/python-argcomplete-tcsh
+++ b/scripts/python-argcomplete-tcsh
@@ -20,4 +20,4 @@ export _ARGCOMPLETE
 _ARGCOMPLETE_SHELL=tcsh
 export _ARGCOMPLETE_SHELL
 
-"$1" 8>&1 9>&2 1>/dev/null 2>/dev/null
+"$1"


### PR DESCRIPTION
### Preface
First of all, thank you for this handy module.
However, I struggled a lot to get it working on Cygwin.
I traced back the issue to the non-standard stream (File descriptor 8), that cannot be opened:
https://github.com/kislyuk/argcomplete/blob/30ff207e9a89bc08b9cb38cbeb21147ef0c23480/argcomplete/__init__.py#L186-L191
### Changes
When this PR is meged it will:
- Get rid of the non-standard streams (FD 8 and 9).
- Handle the suppression of stderr and stdout in `__init__.py` rather than in the shell scripts.
### Additional Notes
- Additionally tested global completion with Bash on CYGWIN_NT-6.3.