### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, pypy3
+envlist = py27, py35, py36, py37, pypy, pypy3
 
 [testenv]
+deps =
+    pexpect
 commands =
     python test/test.py -v


### PR DESCRIPTION
* Add Python 3.7: "py37" env
* Remove unsupported Python version 3.3 and 3.4
* Add test dependency: pexpect