### PR TITLE
Catch exceptions in _check_module

### DIFF
--- a/argcomplete/_check_module.py
+++ b/argcomplete/_check_module.py
@@ -68,10 +68,15 @@ def main():
         raise ArgcompleteMarkerNotFound('missing argument on the command line')
 
     filename = find(name)
+    if hasattr(tokenize, 'open'):
+        open_func = tokenize.open
+    else:
+        open_func = open
+
     try:
-        fp = tokenize.open(filename)
-    except FileNotFoundError:
-        raise ArgcompleteMarkerNotFound('file not found')
+        fp = open_func(filename)
+    except OSError:
+        raise ArgcompleteMarkerNotFound('cannot open file')
 
     with fp:
         head = fp.read(1024)

--- a/argcomplete/_check_module.py
+++ b/argcomplete/_check_module.py
@@ -8,6 +8,7 @@ Intended to be invoked by argcomplete's global completion function.
 """
 import os
 import sys
+import tokenize
 
 try:
     from importlib.util import find_spec
@@ -61,8 +62,20 @@ def find(name, return_package=False):
 
 
 def main():
-    with open(find(sys.argv[1])) as f:
-        head = f.read(1024)
+    try:
+        name = sys.argv[1]
+    except IndexError:
+        raise ArgcompleteMarkerNotFound('missing argument on the command line')
+
+    filename = find(name)
+    try:
+        fp = tokenize.open(filename)
+    except FileNotFoundError:
+        raise ArgcompleteMarkerNotFound('file not found')
+
+    with fp:
+        head = fp.read(1024)
+
     if 'PYTHON_ARGCOMPLETE_OK' not in head:
         raise ArgcompleteMarkerNotFound('marker not found')
 


### PR DESCRIPTION
* _check_module.main() now catchs IndexError and FileNotFoundError
  errors: raise ArgcompleteMarkerNotFound exception instead.
* Replace open() with tokenize.open() to handle "# coding: xxx"
  encoding cookie: support source code using an encoding different
  than UTF-8 on Python 3.