### PR TITLE
Prepend to PYTHONPATH in test_console_script* instead of replacing

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -1185,7 +1185,7 @@ class TestBashGlobal(TestBash):
         with TempDir(prefix='test_dir_py', dir='.'):
             self.sh.run_command('cd ' + os.getcwd())
             self.sh.run_command('export PATH=$PATH:./bin')
-            self.sh.run_command('export PYTHONPATH=.')
+            self.sh.run_command('export PYTHONPATH=.:$PYTHONPATH')
             test_package = os.path.join(TEST_DIR, 'test_package')
             command = 'pip install {} --target .'.format(test_package)
             if not wheel:


### PR DESCRIPTION
Modify _test_console_script() to prepend to PYTHONPATH instead of
overwriting its value.  This is necessary so that it is able to find
just-built version of argcomplete that is provided via PYTHONPATH
(vs requiring it to be installed in system-wide directory prior).

Otherwise, the tests are failing:

    Traceback (most recent call last):
      File "./bin/test-package", line 5, in <module>
        from test_package import main
      File "/tmp/argcomplete/test_dir_pychyg9vqx/test_package/__init__.py", line 4, in <module>
        import argcomplete
    ModuleNotFoundError: No module named 'argcomplete'