### PR TITLE
Reenable testing pypy on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 sudo: required
-dist: bionic
 python:
   - 2.7
   - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - 3.6
   - 3.7
   - 3.8
-#  - pypy
-#  - pypy3
+  - pypy
+  - pypy3
 
 matrix:
   include:


### PR DESCRIPTION
FWICS testing pypy* was disabled because of very old version on Travis.
It's been updated since, so let's try reenabling it.