### PR TITLE
Make arcomplete work with Spack-created console scripts

### DIFF
--- a/argcomplete/bash_completion.d/python-argcomplete.sh
+++ b/argcomplete/bash_completion.d/python-argcomplete.sh
@@ -54,6 +54,9 @@ _python_argcomplete_global() {
             elif __python_argcomplete_run "$interpreter" -m argcomplete._check_console_script "$SCRIPT_NAME"; then
                 local ARGCOMPLETE=1
             fi
+        elif [[ "$(head -n 1 "$SCRIPT_NAME")" =~ ^"#"!/bin/sh$ ]] && [[ "$(head -n 2 "$SCRIPT_NAME" | tail -n 1)" =~ ^\'\'\'exec\'.*(python|pypy)[0-9\.]*.*$ ]]; then
+            # Spack alters shebang using a trick with exec
+            local ARGCOMPLETE=1
         fi
     fi
 


### PR DESCRIPTION
Spack (https://spack.io/) is a package manager for supercomputers.
To avoid overlong shebang problem in some environments
it relies on a trick with wrapping exec in a Python docstring.

Python console scripts have the following form when created by Spack:

```
#!/bin/sh
'''exec' /very/long/path/to/python/installed/within/spack/bin/python3.8 "$0" "$@"
' '''
# -*- coding: utf-8 -*-
import re
import sys
from my_package.__main__ import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())
```

I'm not sure if this PR is general enough to be merged, but I hope that some other users would find it useful.