### PR TITLE
Add -o bashdefault to register-python-argcomplete's output command

### DIFF
--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -74,7 +74,7 @@ def shellcode(executables, use_defaults=True, shell='bash', complete_arguments=N
     '''
 
     if complete_arguments is None:
-        complete_options = '-o nospace -o default -o bashdefault' if use_defaults else '-o nospace'
+        complete_options = '-o nospace -o default -o bashdefault' if use_defaults else '-o nospace -o bashdefault'
     else:
         complete_options = " ".join(complete_arguments)
 

--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -74,7 +74,7 @@ def shellcode(executables, use_defaults=True, shell='bash', complete_arguments=N
     '''
 
     if complete_arguments is None:
-        complete_options = '-o nospace -o default' if use_defaults else '-o nospace'
+        complete_options = '-o nospace -o default -o bashdefault' if use_defaults else '-o nospace'
     else:
         complete_options = " ".join(complete_arguments)
 


### PR DESCRIPTION
Fix https://github.com/kislyuk/argcomplete/issues/67#issuecomment-570475793

Add [`-o bashdefault`](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html) to `register-python-argcomplete`'s output command, so that individual command can complete the environment variables.
