### PR TITLE
Register auto completion for an arbitrary name using a given external script

### DIFF
--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -91,7 +91,7 @@ def shellcode(executables, use_defaults=True, shell='bash', complete_arguments=N
         code = ""
         for executable in executables:
             if not argcomplete_script:
-               argcomplete_script = executable
+                argcomplete_script = executable
             code += shell_codes.get(shell, '') % dict(executable=executable, argcomplete_script=argcomplete_script)
 
     return code

--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -29,7 +29,7 @@ _python_argcomplete() {
                   _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
                   _ARGCOMPLETE=1 \
                   _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
-                  __python_argcomplete_run "$1") )
+                  __python_argcomplete_run "%(argcomplete_script)s") )
     if [[ $? != 0 ]]; then
         unset COMPREPLY
     elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
@@ -40,7 +40,7 @@ complete %(complete_opts)s -F _python_argcomplete %(executables)s
 '''
 
 tcshcode = '''\
-complete "%(executable)s" 'p@*@`python-argcomplete-tcsh "%(executable)s"`@' ;
+complete "%(executable)s" 'p@*@`python-argcomplete-tcsh "%(argcomplete_script)s"`@' ;
 '''
 
 fishcode = r'''
@@ -53,16 +53,18 @@ function __fish_%(executable)s_complete
     set -x COMP_POINT (string length (commandline -cp))
     set -x COMP_TYPE
     if set -q _ARC_DEBUG
-        %(executable)s 8>&1 9>&2 1>/dev/null 2>&1
+        %(argcomplete_script)s 8>&1 9>&2 1>/dev/null 2>&1
     else
-        %(executable)s 8>&1 9>&2 1>&9 2>&1
+        %(argcomplete_script)s 8>&1 9>&2 1>&9 2>&1
     end
 end
 complete -c %(executable)s -f -a '(__fish_%(executable)s_complete)'
 '''
 
+shell_codes = {'bash': bashcode, 'tcsh': tcshcode, 'fish': fishcode}
 
-def shellcode(executables, use_defaults=True, shell='bash', complete_arguments=None):
+
+def shellcode(executables, use_defaults=True, shell='bash', complete_arguments=None, argcomplete_script=None):
     '''
     Provide the shell code required to register a python executable for use with the argcomplete module.
 
@@ -81,14 +83,15 @@ def shellcode(executables, use_defaults=True, shell='bash', complete_arguments=N
     if shell == 'bash':
         quoted_executables = [quote(i) for i in executables]
         executables_list = " ".join(quoted_executables)
-        code = bashcode % dict(complete_opts=complete_options, executables=executables_list)
-    elif shell == 'fish':
-        code = ""
-        for executable in executables:
-            code += fishcode % dict(executable=executable)
+        if not argcomplete_script:
+            argcomplete_script = '$1'
+        code = bashcode % dict(complete_opts=complete_options, executables=executables_list,
+                               argcomplete_script=argcomplete_script)
     else:
         code = ""
         for executable in executables:
-            code += tcshcode % dict(executable=executable)
+            if not argcomplete_script:
+               argcomplete_script = executable
+            code += shell_codes.get(shell, '') % dict(executable=executable, argcomplete_script=argcomplete_script)
 
     return code

--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -43,6 +43,9 @@ parser.add_argument(
     '-s', '--shell',
     choices=('bash', 'tcsh', 'fish'), default='bash',
     help='output code for the specified shell')
+parser.add_argument(
+    '-e', '--external-argcomplete-script',
+    help='external argcomplete script for auto completion of the executable')
 
 parser.add_argument(
     'executable',
@@ -59,4 +62,4 @@ args = parser.parse_args()
 
 
 sys.stdout.write(argcomplete.shellcode(
-    args.executable, args.use_defaults, args.shell, args.complete_arguments))
+    args.executable, args.use_defaults, args.shell, args.complete_arguments, args.external_argcomplete_script))

--- a/test/test.py
+++ b/test/test.py
@@ -753,9 +753,16 @@ class TestArgcomplete(unittest.TestCase):
             fh.write(sc.encode())
             fh.flush()
             subprocess.check_call(['bash', '-n', fh.name])
+        with NamedTemporaryFile() as fh:
+            sc = shellcode(["prog"], use_defaults=True, shell="bash", complete_arguments=None,
+                           argcomplete_script="~/.bash_completion.d/prog.py")
+            fh.write(sc.encode())
+            fh.flush()
+            subprocess.check_call(['bash', '-n', fh.name])
         sc = shellcode(["prog"], use_defaults=False, shell="tcsh", complete_arguments=["-o", "nospace"])
         sc = shellcode(["prog"], use_defaults=False, shell="woosh", complete_arguments=["-o", "nospace"])
         sc = shellcode(["prog"], shell="fish")
+        sc = shellcode(["prog"], shell="fish", argcomplete_script="~/.bash_completion.d/prog.py")
 
 class TestArgcompleteREPL(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Allows to use the auto completion functionality of argcomplete for an application not written in Python. The command line interface of this program must be additionally implemented in a script with argparse and argcomplete and whenever the application is called the registered external script is used for auto completion.

registration:
eval "$(register-python-argcomplete --external-argcomplete-script /path/to/external_script.py arbitrary_app)"