### PR TITLE
Fix traceback and incorrect completions using `SubprocessCompleter`

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -428,6 +428,9 @@ class CompletionFinder(object):
                     completer = self.default_completer
 
             if completer:
+                if isinstance(completer, SuppressCompleter) and completer.suppress():
+                    continue
+
                 if callable(completer):
                     completions_from_callable = [c for c in completer(
                         prefix=cword_prefix, action=active_action, parser=parser, parsed_args=parsed_args)


### PR DESCRIPTION
It looks like using `SuppressCompleter()` (#224) raises during argument completion which results in some completions getting unexpectedly suppressed. This fixes the issue by ~~making `SuppressCompleter()` callable~~ checking if the completions should be suppressed prior to checking what type of completer to use.

## Problem
Consider this python script:

<details><summary>Python script with completion</summary>

```python3
#!/usr/bin/env python3

import argparse
from argcomplete import autocomplete

parser = argparse.ArgumentParser()

arg = parser.add_argument(
    '-p', '--print', '--print-description', default=False, action='store_true',
    help='Print the launch description to the console without launching it.')

arg = parser.add_argument(
    'launch_arguments',
    nargs='*',
    help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)")

autocomplete(parser, exclude=['-h', '--help'])
```
</details>

`./suppress.py <tab><tab>` displays files in the current directory, but I don't want that.

```
$ ./suppress.py 
file_i_dont_want_compeleted.txt  --print                          suppress.py                      .swp
-p                               --print-description              .suppress.py.swp
```

Using `export _ARC_DEBUG=true` I can see the file I don't want completed comes from `launch_arguments`

```
# ...
Active actions (L=1): [IntrospectAction(option_strings=[], dest='launch_arguments', nargs='*', const=None, default=None, type=None, choices=None, help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)", metavar=None)]
Activating completion for IntrospectAction(option_strings=[], dest='launch_arguments', nargs='*', const=None, default=None, type=None, choices=None, help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)", metavar=None) <class 'argparse._StoreAction'>
Completions: ['-h', '--help', '-p', '--print', '--print-description', 'file_i_dont_want_compeleted.txt', '.suppress.py.swp', 'suppress.py', '.swp']
```

So I added `SuppressCompleter` to `launch_arguments`.

<details><summary>Python script with suppressed completion</summary>

```python3
#!/usr/bin/env python3

import argparse
from argcomplete import autocomplete
from argcomplete.completers import SuppressCompleter

parser = argparse.ArgumentParser()

arg = parser.add_argument(
    '-p', '--print', '--print-description', default=False, action='store_true',
    help='Print the launch description to the console without launching it.')

arg = parser.add_argument(
    'launch_arguments',
    nargs='*',
    help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)")
arg.completer = SuppressCompleter()

autocomplete(parser, exclude=['-h', '--help'])
```
</details>

But now with `_ARC_DEBUG` I see an exception:

```
# ...
Active actions (L=1): [IntrospectAction(option_strings=[], dest='launch_arguments', nargs='*', const=None, default=None, type=None, choices=None, help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)", metavar=None)]
Activating completion for IntrospectAction(option_strings=[], dest='launch_arguments', nargs='*', const=None, default=None, type=None, choices=None, help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)", metavar=None) <class 'argparse._StoreAction'>
Completer is not callable, trying the readline completer protocol instead
Traceback (most recent call last):
  File "./suppress.py", line 47, in <module>
    autocomplete(parser, exclude=['-h', '--help'])
  File "/home/sloretz/tmp/argcomplete/argcomplete/__init__.py", line 227, in __call__
    completions = self._get_completions(comp_words, cword_prefix, cword_prequote, last_wordbreak_pos)
  File "/home/sloretz/tmp/argcomplete/argcomplete/__init__.py", line 258, in _get_completions
    completions = self.collect_completions(active_parsers, parsed_args, cword_prefix, debug)
  File "/home/sloretz/tmp/argcomplete/argcomplete/__init__.py", line 481, in collect_completions
    completions)
  File "/home/sloretz/tmp/argcomplete/argcomplete/__init__.py", line 447, in _complete_active_option
    next_completion = completer.complete(cword_prefix, i)
AttributeError: 'SuppressCompleter' object has no attribute 'complete'
```

And the files I don't want completed are still completed, plus the completions for `--print` are gone.

```
$ ./suppress.py 
file_i_dont_want_compeleted.txt  suppress.py                      .suppress.py.swp                 .swp
```
## Workaround
I can work around this by making a subclass that is callable.

<details><summary>Python script with callable subclass of SupressCompleter</summary>

```python3
#!/usr/bin/env python3

import argparse
from argcomplete import autocomplete
from argcomplete.completers import SuppressCompleter


class SuppressCompleterWorkaround(SuppressCompleter):
    """Make SuppressCompleter callable."""

    def __call__(self, *args, **kwargs):
        return tuple()


parser = argparse.ArgumentParser()

arg = parser.add_argument(
    '-p', '--print', '--print-description', default=False, action='store_true',
    help='Print the launch description to the console without launching it.')

arg = parser.add_argument(
    'launch_arguments',
    nargs='*',
    help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)")
arg.completer = SuppressCompleterWorkaround()

autocomplete(parser, exclude=['-h', '--help'])
```
</details>

And that gets the completions I'm looking for:

```
$ ./suppress.py 
-p                   --print              --print-description
```
