### PR TITLE
Fix multiple command registration for non-bash shells

### DIFF
--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -73,7 +73,8 @@ def shellcode(executables, use_defaults=True, shell='bash', complete_arguments=N
     :param str shell: Name of the shell to output code for (bash or tcsh)
     :param complete_arguments: Arguments to call complete with
     :type complete_arguments: list(str) or None
-    :param argcomplete_script: Script to call complete with
+    :param argcomplete_script: Script to call complete with, if not the executable to complete.
+        If supplied, will be used to complete *all* passed executables.
     :type argcomplete_script: str or None
     '''
 
@@ -92,8 +93,10 @@ def shellcode(executables, use_defaults=True, shell='bash', complete_arguments=N
     else:
         code = ""
         for executable in executables:
-            if not argcomplete_script:
-                argcomplete_script = executable
-            code += shell_codes.get(shell, '') % dict(executable=executable, argcomplete_script=argcomplete_script)
+            script = argcomplete_script
+            # If no script was specified, default to the executable being completed.
+            if not script:
+                script = executable
+            code += shell_codes.get(shell, '') % dict(executable=executable, argcomplete_script=script)
 
     return code

--- a/test/test.py
+++ b/test/test.py
@@ -1129,7 +1129,9 @@ class TestBash(_TestSh, unittest.TestCase):
         # This requires compopt which is not available in 3.x.
         expected_failures.append('test_quoted_exact')
 
-    install_cmd = 'eval "$(register-python-argcomplete prog)"'
+    # 'dummy' argument unused; checks multi-command registration works
+    # by passing 'prog' as the second argument.
+    install_cmd = 'eval "$(register-python-argcomplete dummy prog)"'
 
     def setUp(self):
         sh = pexpect.replwrap.bash()
@@ -1244,7 +1246,9 @@ class TestTcsh(_TestSh, unittest.TestCase):
         path = ' '.join([os.path.join(BASE_DIR, 'scripts'), TEST_DIR, '$path'])
         sh.run_command('set path = ({0})'.format(path))
         sh.run_command('setenv PYTHONPATH {0}'.format(BASE_DIR))
-        output = sh.run_command('eval `register-python-argcomplete --shell tcsh prog`')
+        # 'dummy' argument unused; checks multi-command registration works
+        # by passing 'prog' as the second argument.
+        output = sh.run_command('eval `register-python-argcomplete --shell tcsh dummy prog`')
         self.assertEqual(output, '')
         self.sh = sh
 
@@ -1277,7 +1281,9 @@ class TestFish(_TestSh, unittest.TestCase):
         path = ' '.join([os.path.join(BASE_DIR, 'scripts'), TEST_DIR, '$PATH'])
         sh.run_command('set -x PATH {0}'.format(path))
         sh.run_command('set -x PYTHONPATH {0}'.format(BASE_DIR))
-        output = sh.run_command('register-python-argcomplete --shell fish prog | .')
+        # 'dummy' argument unused; checks multi-command registration works
+        # by passing 'prog' as the second argument.
+        output = sh.run_command('register-python-argcomplete --shell fish dummy prog | .')
         self.assertEqual(output, '')
         self.sh = sh
 


### PR DESCRIPTION
Fixes a bug introduced in #288 where the first executable would be used to complete all passed executables if no script was specified.