### PR TITLE
Add support for script completion on Windows via Git Bash

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -177,18 +177,41 @@ class CompletionFinder(object):
             # not an argument completion invocation
             return
 
+        stdout_fd = 8
+        stderr_fd = 9
+
+        def open_osfhandle(handle):
+            import msvcrt
+            return msvcrt.open_osfhandle(handle, os.O_RDONLY | os.O_TEXT)
+
+        stdout_handle = os.environ.get("_ARGCOMPLETE_STDOUT_HANDLE")
+        if stdout_handle is not None:
+            stdout_fd = open_osfhandle(int(stdout_handle))
+        stderr_handle = os.environ.get("_ARGCOMPLETE_STDERR_HANDLE")
+        if stderr_handle is not None:
+            stderr_fd = open_osfhandle(int(stderr_handle))
+
         global debug_stream
         try:
-            debug_stream = os.fdopen(9, "w")
+            debug_stream = os.fdopen(stderr_fd, "w")
         except:
             debug_stream = sys.stderr
 
         if output_stream is None:
             try:
-                output_stream = os.fdopen(8, "wb")
+                output_stream = os.fdopen(stdout_fd, "wb")
             except:
-                debug("Unable to open fd 8 for writing, quitting")
+                debug("Unable to open fd {} for writing, quitting".format(stdout_fd))
                 exit_method(1)
+
+        # Almost always in the middle of a user typing a line;
+        # move to the next line before any other debug output.
+        debug()
+
+        if stdout_handle is not None:
+            debug("Mapped stdout handle {} to fd {}".format(stdout_handle, stdout_fd))
+        if stderr_handle is not None:
+            debug("Mapped stderr handle {} to fd {}".format(stderr_handle, stderr_fd))
 
         # print("", stream=debug_stream)
         # for v in "COMP_CWORD COMP_LINE COMP_POINT COMP_TYPE COMP_KEY _ARGCOMPLETE_COMP_WORDBREAKS COMP_WORDS".split():

--- a/argcomplete/bash_completion.d/python-argcomplete
+++ b/argcomplete/bash_completion.d/python-argcomplete
@@ -15,7 +15,9 @@ __python_argcomplete_expand_tilde_by_ref () {
 # Run something, muting output or redirecting it to the debug stream
 # depending on the value of _ARC_DEBUG.
 __python_argcomplete_run() {
-    if [[ -z "$_ARC_DEBUG" ]]; then
+    if [[ "$OS" == "Windows_NT" ]]; then
+        __python_argcomplete_run_subprocess "$@"
+    elif [[ -z "$_ARC_DEBUG" ]]; then
         "$@" 8>&1 9>&2 1>/dev/null 2>&1
     else
         "$@" 8>&1 9>&2 1>&9 2>&1

--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -9,7 +9,9 @@ bashcode = r'''
 # Run something, muting output or redirecting it to the debug stream
 # depending on the value of _ARC_DEBUG.
 __python_argcomplete_run() {
-    if [[ -z "$_ARC_DEBUG" ]]; then
+    if [[ "$OS" == "Windows_NT" ]]; then
+        __python_argcomplete_run_subprocess "$@"
+    elif [[ -z "$_ARC_DEBUG" ]]; then
         "$@" 8>&1 9>&2 1>/dev/null 2>&1
     else
         "$@" 8>&1 9>&2 1>&9 2>&1

--- a/scripts/__python_argcomplete_run_subprocess
+++ b/scripts/__python_argcomplete_run_subprocess
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""
+Script mimicking __python_argcomplete_run using subprocess.
+
+Used in environments where the file descriptor manipulation
+required by argcomplete is not possible from shell scripts.
+"""
+import os
+import msvcrt
+import subprocess
+import sys
+
+if '_ARC_DEBUG' in os.environ:
+    stdout = sys.stderr.buffer
+else:
+    stdout = subprocess.DEVNULL
+
+# Inform the child of stdout/stderr handles via the environment.
+# These handles are inherited by setting close_fds=False.
+# They appear to be inheritable by default;
+# alternatively we could use os.set_handle_inheritable().
+# We use handles instead of file descriptors
+# because they are more easily inherited on Windows.
+# Even if we create the file descriptors, make them inheritable
+# and use os.spawn* instead of subprocess so that the
+# file descriptors are inherited by py.exe,
+# py.exe won't pass them to the Python process it spawns anyway.
+# See also: https://www.python.org/dev/peps/pep-0446/#inheritance-of-file-descriptors-on-windows
+stdout_handle = msvcrt.get_osfhandle(1)
+stderr_handle = msvcrt.get_osfhandle(2)
+env = os.environ.copy()
+env['_ARGCOMPLETE_STDOUT_HANDLE'] = str(stdout_handle)
+env['_ARGCOMPLETE_STDERR_HANDLE'] = str(stderr_handle)
+
+code = subprocess.call(
+    # bash.exe reads the shebang line in order to execute programs.
+    # cmd.exe uses the file association for .py files
+    # to launch scripts using py.exe, which reads the shebang line.
+    # subprocess does neither of these things,
+    # so we explicitly launch via py.exe.
+    # This will only work for scripts; it won't work for
+    # pip wrappers (which are .exe files on Windows)
+    # or for completing py.exe or python.exe.
+    ['py.exe'] + sys.argv[1:],
+    stdout=stdout,
+    stderr=subprocess.STDOUT,
+    close_fds=False,
+    env=env,
+)
+sys.exit(code)


### PR DESCRIPTION
* How does this impact WSL users?
    * Is the OS environment variable set there?
    * Should we make this feature opt-in instead?
* Global completion of python/py does not work
    * Should be fixable with a flag to tell the script not to launch via py.exe
* Completion of pip-generated script wrappers does not work
    * Much harder; existing logic parses the wrapper to find the correct interpreter to then find the script to check for the argcomplete marker
    * Alternatively we could just guess an interpreter and hope for the best