### PR TITLE
Add partial support for script completion on Windows via Git Bash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -282,6 +282,16 @@ or create new completion file, e.g::
 
     register-python-argcomplete --shell fish ~/.config/fish/completions/my-awesome-script.fish
 
+Git Bash Support
+----------------
+Due to limitations of file descriptor inheritance on Windows,
+Git Bash is only partially supported. You can opt-in to the
+Windows compatibility layer by setting the environment variable
+``ARGCOMPLETE_WINDOWS_COMPAT``.
+
+For full support, consider using Bash with the
+Windows Subsystem for Linux (WSL).
+
 External argcomplete script
 ---------------------------
 To register an argcomplete script for an arbitrary name, the ``--external-argcomplete-script`` argument of the ``register-python-argcomplete`` script can be used::

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -177,18 +177,48 @@ class CompletionFinder(object):
             # not an argument completion invocation
             return
 
+        stdout_fd = 8
+        stderr_fd = 9
+
+        def open_osfhandle(handle):
+            import msvcrt
+            # Unsure what purpose the flags serve;
+            # we seem to be able to open the returned file descriptors
+            # in whatever mode we please via os.fdopen() anyway.
+            return msvcrt.open_osfhandle(handle, 0)
+
+        # On Windows, if the caller has created inheritable handles
+        # and passed them via environment variables,
+        # we will convert them to file descriptors
+        # and use them in place of the default 8 and 9.
+        stdout_handle = os.environ.get("_ARGCOMPLETE_STDOUT_HANDLE")
+        if stdout_handle is not None:
+            stdout_fd = open_osfhandle(int(stdout_handle))
+        stderr_handle = os.environ.get("_ARGCOMPLETE_STDERR_HANDLE")
+        if stderr_handle is not None:
+            stderr_fd = open_osfhandle(int(stderr_handle))
+
         global debug_stream
         try:
-            debug_stream = os.fdopen(9, "w")
+            debug_stream = os.fdopen(stderr_fd, "w")
         except:
             debug_stream = sys.stderr
 
         if output_stream is None:
             try:
-                output_stream = os.fdopen(8, "wb")
+                output_stream = os.fdopen(stdout_fd, "wb")
             except:
-                debug("Unable to open fd 8 for writing, quitting")
+                debug("Unable to open fd {} for writing, quitting".format(stdout_fd))
                 exit_method(1)
+
+        # Almost always in the middle of a user typing a line;
+        # move to the next line before any other debug output.
+        debug()
+
+        if stdout_handle is not None:
+            debug("Mapped stdout handle {} to fd {}".format(stdout_handle, stdout_fd))
+        if stderr_handle is not None:
+            debug("Mapped stderr handle {} to fd {}".format(stderr_handle, stderr_fd))
 
         # print("", stream=debug_stream)
         # for v in "COMP_CWORD COMP_LINE COMP_POINT COMP_TYPE COMP_KEY _ARGCOMPLETE_COMP_WORDBREAKS COMP_WORDS".split():

--- a/argcomplete/bash_completion.d/python-argcomplete
+++ b/argcomplete/bash_completion.d/python-argcomplete
@@ -15,6 +15,14 @@ __python_argcomplete_expand_tilde_by_ref () {
 # Run something, muting output or redirecting it to the debug stream
 # depending on the value of _ARC_DEBUG.
 __python_argcomplete_run() {
+    if [[ ! -z "$ARGCOMPLETE_WINDOWS_COMPAT" ]]; then
+        if [[ -z "$_ARC_DEBUG" ]]; then
+            __python_argcomplete_run_windows "$@" 2>/dev/null
+        else
+            __python_argcomplete_run_windows "$@"
+        fi
+        return
+    fi
     if [[ -z "$_ARC_DEBUG" ]]; then
         "$@" 8>&1 9>&2 1>/dev/null 2>&1
     else

--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -9,6 +9,14 @@ bashcode = r'''
 # Run something, muting output or redirecting it to the debug stream
 # depending on the value of _ARC_DEBUG.
 __python_argcomplete_run() {
+    if [[ ! -z "$ARGCOMPLETE_WINDOWS_COMPAT" ]]; then
+        if [[ -z "$_ARC_DEBUG" ]]; then
+            __python_argcomplete_run_windows "$@" 2>/dev/null
+        else
+            __python_argcomplete_run_windows "$@"
+        fi
+        return
+    fi
     if [[ -z "$_ARC_DEBUG" ]]; then
         "$@" 8>&1 9>&2 1>/dev/null 2>&1
     else

--- a/scripts/__python_argcomplete_run_windows
+++ b/scripts/__python_argcomplete_run_windows
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Script mimicking __python_argcomplete_run using subprocess.
+
+Runs a Python script as a subprocess, printing completions on stdout
+and any other output on stderr.
+
+Called by the shell wrappers when ARGCOMPLETE_WINDOWS_COMPAT
+is defined in the environment.
+
+Useful in Windows environments where the file descriptor manipulation
+required by argcomplete is not possible from shell scripts,
+for example with a typical install of Git Bash.
+
+This script uses msvcrt; it is not suitable for use on non-Windows platforms.
+"""
+import os
+import msvcrt
+import subprocess
+import sys
+
+assert 'ARGCOMPLETE_WINDOWS_COMPAT' in os.environ
+
+# Inform the child of stdout/stderr handles via the environment.
+# These handles are inherited by setting close_fds=False.
+# They appear to be inheritable by default;
+# alternatively we could use os.set_handle_inheritable().
+# We use handles instead of file descriptors
+# because they are more easily inherited on Windows.
+# Even if we create the file descriptors, make them inheritable
+# and use os.spawn* instead of subprocess so that the
+# file descriptors are inherited by py.exe,
+# py.exe won't pass them to the Python process it spawns anyway.
+# See also: https://www.python.org/dev/peps/pep-0446/#inheritance-of-file-descriptors-on-windows
+stdout_handle = msvcrt.get_osfhandle(1)
+stderr_handle = msvcrt.get_osfhandle(2)
+env = os.environ.copy()
+env['_ARGCOMPLETE_STDOUT_HANDLE'] = str(stdout_handle)
+env['_ARGCOMPLETE_STDERR_HANDLE'] = str(stderr_handle)
+
+code = subprocess.call(
+    # bash.exe reads the shebang line in order to execute programs.
+    # cmd.exe uses the file association for .py files
+    # to launch scripts using py.exe, which reads the shebang line.
+    # subprocess does neither of these things,
+    # so we explicitly launch via py.exe.
+    # This will only work for scripts; it won't work for
+    # pip wrappers (which are .exe files on Windows)
+    # or for completing py.exe or python.exe.
+    ['py.exe'] + sys.argv[1:],
+    # Both the child's stdout and stderr go to our stderr.
+    stdout=sys.stderr.buffer,
+    stderr=subprocess.STDOUT,
+    close_fds=False,
+    env=env,
+)
+sys.exit(code)


### PR DESCRIPTION
Supersedes #305 

This should have no observable impact unless the user explicitly opts in to this change by setting ARGCOMPLETE_WINDOWS_COMPAT, meaning that existing users using Bash with WSL will not see any change.

I believe this is compatible with the approach I described in #302, where PowerShell could pass a pipe handle via _ARGCOMPLETE_STDOUT_HANDLE. There is actually no need to do the same for the debug stream, since argcomplete already falls back on stderr.

@kislyuk Are you happy with this approach? Happy to answer questions if any of my code or comments are unclear.