### PR TITLE
Add option to use tempfiles for IPC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -282,6 +282,17 @@ or create new completion file, e.g::
 
     register-python-argcomplete --shell fish ~/.config/fish/completions/my-awesome-script.fish
 
+Git Bash Support
+----------------
+Due to limitations of file descriptor inheritance on Windows,
+Git Bash not supported out of the box. You can opt in to using
+temporary files instead of file descriptors for for IPC
+by setting the environment variable ``ARGCOMPLETE_USE_TEMPFILES``,
+e.g. by adding ``export ARGCOMPLETE_USE_TEMPFILES=1`` to ``~/.bashrc``.
+
+For full support, consider using Bash with the
+Windows Subsystem for Linux (WSL).
+
 External argcomplete script
 ---------------------------
 To register an argcomplete script for an arbitrary name, the ``--external-argcomplete-script`` argument of the ``register-python-argcomplete`` script can be used::

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -182,6 +182,13 @@ class CompletionFinder(object):
             debug_stream = os.fdopen(9, "w")
         except:
             debug_stream = sys.stderr
+        debug()
+
+        if output_stream is None:
+            filename = os.environ.get("_ARGCOMPLETE_STDOUT_FILENAME")
+            if filename is not None:
+                debug("Using output file {}".format(filename))
+                output_stream = open(filename, "wb")
 
         if output_stream is None:
             try:

--- a/argcomplete/bash_completion.d/python-argcomplete
+++ b/argcomplete/bash_completion.d/python-argcomplete
@@ -14,7 +14,21 @@ __python_argcomplete_expand_tilde_by_ref () {
 
 # Run something, muting output or redirecting it to the debug stream
 # depending on the value of _ARC_DEBUG.
+# If ARGCOMPLETE_USE_TEMPFILES is set, use tempfiles for IPC.
 __python_argcomplete_run() {
+    if [[ -z "$ARGCOMPLETE_USE_TEMPFILES" ]]; then
+        __python_argcomplete_run_inner "$@"
+        return
+    fi
+    local tmpfile="$(mktemp)"
+    _ARGCOMPLETE_STDOUT_FILENAME="$tmpfile" __python_argcomplete_run_inner "$@"
+    local code=$?
+    cat "$tmpfile"
+    rm "$tmpfile"
+    return $code
+}
+
+__python_argcomplete_run_inner() {
     if [[ -z "$_ARC_DEBUG" ]]; then
         "$@" 8>&1 9>&2 1>/dev/null 2>&1
     else

--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -8,7 +8,21 @@ except ImportError:
 bashcode = r'''
 # Run something, muting output or redirecting it to the debug stream
 # depending on the value of _ARC_DEBUG.
+# If ARGCOMPLETE_USE_TEMPFILES is set, use tempfiles for IPC.
 __python_argcomplete_run() {
+    if [[ -z "$ARGCOMPLETE_USE_TEMPFILES" ]]; then
+        __python_argcomplete_run_inner "$@"
+        return
+    fi
+    local tmpfile="$(mktemp)"
+    _ARGCOMPLETE_STDOUT_FILENAME="$tmpfile" __python_argcomplete_run_inner "$@"
+    local code=$?
+    cat "$tmpfile"
+    rm "$tmpfile"
+    return $code
+}
+
+__python_argcomplete_run_inner() {
     if [[ -z "$_ARC_DEBUG" ]]; then
         "$@" 8>&1 9>&2 1>/dev/null 2>&1
     else

--- a/test/test.py
+++ b/test/test.py
@@ -1197,6 +1197,14 @@ class TestBash(_TestSh, unittest.TestCase):
         self.assertIn('PYTHON_ARGCOMPLETE_STDERR\r\n', output)
         self.assertTrue(output.endswith('foo\r\n'))
 
+    def test_temp_file(self):
+        self.sh.run_command('export ARGCOMPLETE_USE_TEMPFILES=1')
+        self.assertEqual(self.sh.run_command('prog basic f\t'), 'foo\r\n')
+        # Confirm we used a temp file by searching for the debug message.
+        self.sh.run_command('export _ARC_DEBUG=1')
+        output = self.sh.run_command('prog basic f\t')
+        self.assertIn('Using output file ', output)
+
 
 @unittest.skipIf(BASH_MAJOR_VERSION < 4, 'complete -D not supported')
 class TestBashGlobal(TestBash):


### PR DESCRIPTION
Supersedes #306, fixes #267, fixes #142.

Adds support for Git Bash (and potentially other shells on Windows) by giving the option to use a file for IPC instead of file descriptors.

Currently this feature is opt-in as described in the README.