### PR TITLE
`.` command is deprecated as for fish shell #308: changed to source

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -276,7 +276,7 @@ Fish Support
 ------------
 To activate completions for fish use::
 
-    register-python-argcomplete --shell fish my-awesome-script | .
+    register-python-argcomplete --shell fish my-awesome-script | source
 
 or create new completion file, e.g::
 


### PR DESCRIPTION
#308 fix