### PR TITLE
Allow overwriting CompletionFinder debug_stream

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -147,6 +147,8 @@ class CompletionFinder(object):
             Method used to stop the program after printing completions. Defaults to :meth:`os._exit`. If you want to
             perform a normal exit that calls exit handlers, use :meth:`sys.exit`.
         :type exit_method: callable
+        :param output_stream: Stream object to write output to, or None for default behavior.
+        :type output_stream: file-like object or None
         :param exclude: List of strings representing options to be omitted from autocompletion
         :type exclude: iterable
         :param validator:

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -12,16 +12,16 @@ from .shell_integration import shellcode
 
 _DEBUG = "_ARC_DEBUG" in os.environ
 
-debug_stream = sys.stderr
+_debug_stream = sys.stderr
 
 def debug(*args):
     if _DEBUG:
         if USING_PYTHON2:
-            # debug_stream has to be binary mode in Python 2.
+            # _debug_stream has to be binary mode in Python 2.
             # Attempting to write unicode directly uses the default ascii conversion.
             # Convert any unicode to bytes, leaving non-string input alone.
             args = [ensure_bytes(x) if isinstance(x, str) else x for x in args]
-        print(file=debug_stream, *args)
+        print(file=_debug_stream, *args)
 
 BASH_FILE_COMPLETION_FALLBACK = 79
 BASH_DIR_COMPLETION_FALLBACK = 80
@@ -177,11 +177,11 @@ class CompletionFinder(object):
             # not an argument completion invocation
             return
 
-        global debug_stream
+        global _debug_stream
         try:
-            debug_stream = os.fdopen(9, "w")
+            _debug_stream = os.fdopen(9, "w")
         except:
-            debug_stream = sys.stderr
+            _debug_stream = sys.stderr
         debug()
 
         if output_stream is None:
@@ -197,9 +197,9 @@ class CompletionFinder(object):
                 debug("Unable to open fd 8 for writing, quitting")
                 exit_method(1)
 
-        # print("", stream=debug_stream)
+        # print("", stream=_debug_stream)
         # for v in "COMP_CWORD COMP_LINE COMP_POINT COMP_TYPE COMP_KEY _ARGCOMPLETE_COMP_WORDBREAKS COMP_WORDS".split():
-        #     print(v, os.environ[v], stream=debug_stream)
+        #     print(v, os.environ[v], stream=_debug_stream)
 
         ifs = os.environ.get("_ARGCOMPLETE_IFS", "\013")
         if len(ifs) != 1:
@@ -247,7 +247,7 @@ class CompletionFinder(object):
         debug("\nReturning completions:", completions)
         output_stream.write(ifs.join(completions).encode(sys_encoding))
         output_stream.flush()
-        debug_stream.flush()
+        _debug_stream.flush()
         exit_method(0)
 
     def _get_completions(self, comp_words, cword_prefix, cword_prequote, last_wordbreak_pos):
@@ -681,4 +681,4 @@ def warn(*args):
     Prints **args** to standard error when running completions. This will interrupt the user's command line interaction;
     use it to indicate an error condition that is preventing your completer from working.
     """
-    print("\n", file=debug_stream, *args)
+    print("\n", file=_debug_stream, *args)

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -130,7 +130,8 @@ class CompletionFinder(object):
             append_space = os.environ.get("_ARGCOMPLETE_SUPPRESS_SPACE") != "1"
         self.append_space = append_space
 
-    def __call__(self, argument_parser, always_complete_options=True, exit_method=os._exit, output_stream=None,
+    def __call__(self, argument_parser, always_complete_options=True,
+                 exit_method=os._exit, output_stream=None, debug_stream=None,
                  exclude=None, validator=None, print_suppressed=False, append_space=None,
                  default_completer=FilesCompleter()):
         """
@@ -149,6 +150,8 @@ class CompletionFinder(object):
         :type exit_method: callable
         :param output_stream: Stream object to write output to, or None for default behavior.
         :type output_stream: file-like object or None
+        :param debug_stream: Stream object to write debug output to, or None for default behavior.
+        :type debug_stream: file-like object or None
         :param exclude: List of strings representing options to be omitted from autocompletion
         :type exclude: iterable
         :param validator:
@@ -181,10 +184,13 @@ class CompletionFinder(object):
             return
 
         global _debug_stream
-        try:
-            _debug_stream = os.fdopen(9, "w")
-        except:
-            _debug_stream = sys.stderr
+        if debug_stream:
+            _debug_stream = debug_stream
+        else:
+            try:
+                _debug_stream = os.fdopen(9, "w")
+            except:
+                _debug_stream = sys.stderr
         debug()
 
         if output_stream is None:

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -110,7 +110,8 @@ def default_validator(completion, prefix):
 class CompletionFinder(object):
     """
     Inherit from this class if you wish to override any of the stages below. Otherwise, use
-    ``argcomplete.autocomplete()`` directly (it's a convenience instance of this class). It has the same signature as
+    ``argcomplete.autocomplete()`` directly (it's a convenience instance of this class). It
+    has a subset of the arguments of
     :meth:`CompletionFinder.__call__()`.
     """
     def __init__(self, argument_parser=None, always_complete_options=True, exclude=None, validator=None,

--- a/test/test.py
+++ b/test/test.py
@@ -828,6 +828,25 @@ class TestArgcomplete(unittest.TestCase):
         os.environ["_ARGCOMPLETE_DFS"] = "invalid"
         self.assertRaises(Exception, self.run_completer, p, "prog --b")
 
+    def test_debug_stream(self):
+        p = ArgumentParser()
+        p.add_argument("--foo")
+        p.add_argument("--bar")
+
+        import argcomplete
+        from argcomplete.my_shlex import StringIO
+        origdebug = argcomplete._DEBUG
+        try:
+            argcomplete._DEBUG = True
+            debug_stream = StringIO()
+            completions = self.run_completer(p, "prog ",
+                    debug_stream=debug_stream)
+            self.assertEqual(set(completions), set(["-h", "--help", "--foo", "--bar"]))
+            self.assertTrue("lexer state" in debug_stream.getvalue())
+        finally:
+            argcomplete._DEBUG = origdebug
+
+
 class TestArgcompleteREPL(unittest.TestCase):
     def setUp(self):
         pass


### PR DESCRIPTION
We use argcomplete for `virt-install` (part of [virt-manager](https://github.com/virt-manager/virt-manager)) and it works great for us!

virt-install command line syntax is quite large and we have
many argument substrings, so we implement custom completer
functions. Naturally we want to test this as well, so we have
some unittest infrastructure for hitting this code. We capture
output by overriding the CompletionFinder output_stream=
argument.

I'm working on moving virt-manager to use pytest as our test
runner, but our completion tests were triggering weird pytest
behavior. After the first completer test was run the pytest
debug logs would show lots of 'Bad file descriptor' errors
and no more test results would be reported.

This seems to have something to do with CompletionFinder
debug_stream behavior, which will unconditionally attempt to
interact with fd=8 if it is available. For the shell case
this is desired behavior but maybe not for the unittest case.

This small series adds a debug_stream option similar to
output_stream, to allow API users to override the debug_stream
default behavior. I verified this can be used to avoid the
issues I'm seeing with pytest.

Patch #1 renames the global debug_stream, so we can use that
variable name for the __call__ signature.

Patch #2+#3 fix some doc issues in this area.

Patch #4 adds debug_stream argument and test coverage