### PR TITLE
Print `warn()` message from beginning of line

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -683,6 +683,5 @@ def warn(*args):
     """
     # Don't be tempted to use `print("\n",..., *args)`,
     # as that will indent **args** by one space character
-
     print(file=debug_stream)
     print(file=debug_stream, *args)

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -681,4 +681,7 @@ def warn(*args):
     Prints **args** to standard error when running completions. This will interrupt the user's command line interaction;
     use it to indicate an error condition that is preventing your completer from working.
     """
-    print("\n", file=debug_stream, *args)
+    # Don't be tempted to use `print("\n",..., *args)`,
+    # as that will indent **args** by one space character
+    print()
+    print(file=debug_stream, *args)

--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -683,5 +683,6 @@ def warn(*args):
     """
     # Don't be tempted to use `print("\n",..., *args)`,
     # as that will indent **args** by one space character
-    print()
+
+    print(file=debug_stream)
     print(file=debug_stream, *args)

--- a/test/test.py
+++ b/test/test.py
@@ -1409,7 +1409,7 @@ class Warn(unittest.TestCase):
             try:
                 yield
             finally:
-                argcomplete.debug_stream = debug_stream              
+                argcomplete.debug_stream = debug_stream
 
         test_stream = io.StringIO()
         with redirect_debug_stream(test_stream):


### PR DESCRIPTION
The previous behavior was to indent the message by one space character.

Fixes #334 