### PR TITLE
Fix fish support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -280,7 +280,7 @@ To activate completions for fish use::
 
 or create new completion file, e.g::
 
-    register-python-argcomplete --shell fish ~/.config/fish/completions/my-awesome-script.fish
+    register-python-argcomplete --shell fish my-awesome-script > ~/.config/fish/completions/my-awesome-script.fish
 
 Completion Description For Fish
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -68,9 +68,9 @@ function __fish_%(executable)s_complete
     set -x COMP_POINT (string length (commandline -cp))
     set -x COMP_TYPE
     if set -q _ARC_DEBUG
-        %(argcomplete_script)s 8>&1 9>&2 1>/dev/null 2>&1
-    else
         %(argcomplete_script)s 8>&1 9>&2 1>&9 2>&1
+    else
+        %(argcomplete_script)s 8>&1 9>&2 1>/dev/null 2>&1
     end
 end
 complete -c %(executable)s -f -a '(__fish_%(executable)s_complete)'


### PR DESCRIPTION
Although fish-shell support was implemented in https://github.com/kislyuk/argcomplete/pull/260, I think some parts are wrong.

1. Probably [if-condition for _ARC_DEBUG in shell_integration.py](https://github.com/kislyuk/argcomplete/blob/d4197606e3b342d49ec4a9ed51f2fe89a603b3f0/argcomplete/shell_integration.py#L70-L74) is reversed
    - It seems to output to `/dev/null` when `_ARC_DEBUG` **is set**.
2. [Fish Support section in README.rst](https://github.com/kislyuk/argcomplete#fish-support) is different from [comments in register-python-argcomplete](https://github.com/kislyuk/argcomplete/blob/d4197606e3b342d49ec4a9ed51f2fe89a603b3f0/scripts/register-python-argcomplete#L23)
    - README
        - `register-python-argcomplete --shell fish ~/.config/fish/completions/my-awesome-script.fish`
    - register-python-argcomplete
        - `register-python-argcomplete --shell fish my-favourite-script.py > ~/.config/fish/my-favourite-script.py.fish`



@kislyuk @volkov Could you please take a look? Thank you.