### PR TITLE
Truncate input after cursor. Fixes #351

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -59,6 +59,7 @@ class ArgcompleteException(Exception):
 def split_line(line, point=None):
     if point is None:
         point = len(line)
+    line = line[:point]
     lexer = shlex.shlex(line, posix=True)
     lexer.whitespace_split = True
     lexer.wordbreaks = os.environ.get("_ARGCOMPLETE_COMP_WORDBREAKS", "")


### PR DESCRIPTION
Need to think under what circumstances we might want to scan ahead in the command line to let characters after the cursor affect parser state. This might never be a good idea if any quoting is going on, since the downstream state will be inconsistent for any incomplete quotes. However it might also be very useful in some circumstances.