### PR TITLE
Replace assertRaisesRegexp with assertRaisesRegex

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -1047,7 +1047,7 @@ class TestCheckModule(unittest.TestCase):
 
     def test_not_package(self):
         self._mkfile('module.py')
-        with self.assertRaisesRegexp(Exception, 'module is not a package'):
+        with self.assertRaisesRegex(Exception, 'module is not a package'):
             _check_module.find('module.bad')
         self.assertNotIn('module', sys.modules)
 


### PR DESCRIPTION
Deprecated since Python 3.2: 

* https://docs.python.org/3.10/library/unittest.html#deprecated-aliases

Removed in Python 3.11:

* https://docs.python.org/3.11/whatsnew/3.11.html#removed
