### PR TITLE
Fix assertRaisesRegex for Python 2.7

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -10,6 +10,7 @@ from tempfile import TemporaryFile, NamedTemporaryFile, mkdtemp
 try:
     # Python 2
     from cStringIO import StringIO
+    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 except ImportError:
     # Python 3
     from io import StringIO


### PR DESCRIPTION
Follow on from https://github.com/kislyuk/argcomplete/pull/357.

Fixes https://github.com/kislyuk/argcomplete/pull/357#issuecomment-962599827.

Maintain support for Python 2.7.