### PR TITLE
Tests: Disable bracketed paste by default

### DIFF
--- a/test/inputrc
+++ b/test/inputrc
@@ -1,0 +1,1 @@
+set enable-bracketed-paste off

--- a/test/test.py
+++ b/test/test.py
@@ -3,6 +3,7 @@
 import argparse
 import contextlib
 import os
+import os.path
 import shutil
 import subprocess
 import sys
@@ -38,6 +39,10 @@ BASH_VERSION = subprocess.check_output(["bash", "-c", "echo $BASH_VERSION"]).dec
 BASH_MAJOR_VERSION = int(BASH_VERSION.split(".")[0])
 FISH_VERSION_STR = subprocess.check_output(["fish", "-c", "echo -n $version"]).decode()
 FISH_VERSION_TUPLE = tuple(int(x) for x in FISH_VERSION_STR.split("."))
+
+
+def setUpModule():
+    os.environ['INPUTRC'] = os.path.join(os.path.dirname(__file__), 'inputrc')
 
 
 class TempDir(object):


### PR DESCRIPTION
See https://github.com/kislyuk/argcomplete/issues/337#issuecomment-771835184

Fixes #337 #354 #365 via [unittest.setupModule](https://docs.python.org/3/library/unittest.html#setupmodule-and-teardownmodule)