### PR TITLE
Update importlib-metadata dependency requirements to include versions ^5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 install_requires = []
 tests_require = ["coverage", "flake8", "pexpect", "wheel"]
-importlib_backport_requires = ["importlib-metadata >= 0.23, < 5"]
+importlib_backport_requires = ["importlib-metadata >= 0.23, < 6"]
 
 setup(
     name="argcomplete",


### PR DESCRIPTION
Why:

argcomplete appears to be a dependency of many packages and can't be installed along with packages that require importlib-metadata>=5 pacakge (e.g. [djlint](https://github.com/Riverside-Healthcare/djLint/blob/master/pyproject.toml#L37), in my case, but I'm sure there will be more in future). This change makes such installations possible.