### PR TITLE
Support PowerShell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -328,6 +328,17 @@ The command line interface of this program must be additionally implemented in a
 
 This option can also be used in combination with the other supported shells.
 
+PowerShell Support
+------------
+To create new completion file, e.g::
+
+    register-python-argcomplete --shell powershell my-awesome-script > ~/my-awesome-script.psm1
+
+To activate completions for PowerShell, add the below line in ``$PROFILE``. For more information, see `How to create your profile <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.3#how-to-create-a-profile>`_ and `Profiles and execution policy <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.3#profiles-and-execution-policy>`_. ::
+
+    Import-Module  "~/my-awesome-script.psm1"
+
+
 Python Support
 --------------
 Argcomplete requires Python 3.6+.

--- a/scripts/register-python-argcomplete
+++ b/scripts/register-python-argcomplete
@@ -43,7 +43,8 @@ parser.add_argument(
     help="arguments to call complete with; use of this option discards default options",
 )
 parser.add_argument(
-    "-s", "--shell", choices=("bash", "tcsh", "fish"), default="bash", help="output code for the specified shell"
+    "-s", "--shell", choices=("bash", "tcsh", "fish", "powershell"), default="bash",
+    help="output code for the specified shell"
 )
 parser.add_argument(
     "-e", "--external-argcomplete-script", help="external argcomplete script for auto completion of the executable"

--- a/scripts/register-python-argcomplete.cmd
+++ b/scripts/register-python-argcomplete.cmd
@@ -1,0 +1,1 @@
+@python "%~dp0\register-python-argcomplete" %*


### PR DESCRIPTION
In https://github.com/kislyuk/argcomplete/pull/307, argcomplete adds the env `ARGCOMPLETE_USE_TEMPFILES` to redirect its output to file and supports Git Bash. We can use the same way to support powershell.

I've used it in https://github.com/Azure/azure-cli/pull/24752, and it works.