### PR TITLE
Removed part of fish global completion doc after fish-shell fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,13 +298,7 @@ If script is not in path you still can register it's completion by specifying ab
 
     register-python-argcomplete --shell fish /home/awesome-user/my-awesome-script | source
 
-then you can complete it by using ``/home/awesome-user/my-awesome-script`` or ``./my-awesome-script``.
-
-Unfortunately ``~/my-awesome-script`` would not work, to fix it you can run::
-
-    register-python-argcomplete --shell fish my-awesome-script -e /home/awesome-user/my-awesome-script | source
-
-This would enable completion for any ``my-awesome-script`` in any location.
+then you can complete it by using ``/home/awesome-user/my-awesome-script`` or ``./my-awesome-script`` or ``~/my-awesome-script``.
 
 Git Bash Support
 ----------------

--- a/test/test.py
+++ b/test/test.py
@@ -1391,13 +1391,14 @@ class TestFish(_TestSh, unittest.TestCase):
             self.sh.run_command("")
 
 
-@unittest.skipIf(FISH_VERSION_TUPLE < (3, 3), "Path completion is fixed in fish 3.3")
+@unittest.skipIf(FISH_VERSION_TUPLE < (3, 4), "Path completion is fixed in fish 3.4")
 class TestFishPathCompletion(unittest.TestCase):
     def setUp(self):
         sh = Shell("fish")
         path = " ".join([os.path.join(BASE_DIR, "scripts"), "$PATH"])
         sh.run_command("set -x PATH {0}".format(path))
         sh.run_command("set -x PYTHONPATH {0}".format(BASE_DIR))
+        sh.run_command("set -x TEST_DIR {0}".format(TEST_DIR))
         self.assertEqual(
             sh.run_command("register-python-argcomplete --shell fish {0}/prog | source".format(TEST_DIR)), ""
         )
@@ -1406,6 +1407,7 @@ class TestFishPathCompletion(unittest.TestCase):
 
     def test_path_completion(self):
         self.assertEqual(self.sh.run_command("{}/prog basic f\t".format(TEST_DIR)), "foo\r\n")
+        self.assertEqual(self.sh.run_command("$TEST_DIR/prog basic f\t".format(TEST_DIR)), "foo\r\n")
         self.sh.run_command("cd {}".format(TEST_DIR))
         self.assertEqual(self.sh.run_command("./prog basic f\t"), "foo\r\n")
 


### PR DESCRIPTION
In fish-shell/fish-shell#8442 global completion was fixed, so we don't need workaround anymore