### PR TITLE
mypy: Strict annotations / typings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,4 @@ addopts = [
 files = [
   "argcomplete"
 ]
+strict = true


### PR DESCRIPTION
## Instructions

```console
pip install -e '.[test,lint]'
```

Run mypy:

```console
mypy
```

If using [`entr(1)`](https://github.com/eradman/entr) for file-watching:

```console
ls argcomplete/**/*.py | entr -r 'mypy'
```

## Meta

Simple typings: #378
Earlier PR (recut from): #397
Fixes #377