### PR TITLE
setup.py: exclude test.* subpackages from find_packages too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         ':python_version == "3.6"': importlib_backport_requires,
         ':python_version == "3.7"': importlib_backport_requires,
     },
-    packages=find_packages(exclude=["test"]),
+    packages=find_packages(exclude=["test", "test.*"]),
     scripts=glob.glob("scripts/*"),
     package_data={"argcomplete": ["bash_completion.d/python-argcomplete"]},
     zip_safe=False,


### PR DESCRIPTION
Otherwise, test.test_package will be picked up when installing via PEP517.

Bug: https://bugs.gentoo.org/899628