### PR TITLE
Note completers can return iterables of strings, not just lists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ readline-style. Callable completers are simpler. They are called with the follow
 * ``parsed_args``: The result of argument parsing so far (the ``argparse.Namespace`` args object normally returned by
   ``ArgumentParser.parse_args()``).
 
-Completers can return their completions as a sequence (list) of strings or a mapping (dict) of strings to their
+Completers can return their completions as an iterable of strings or a mapping (dict) of strings to their
 descriptions (zsh will display the descriptions as context help alongside completions). An example completer for names
 of environment variables might look like this:
 


### PR DESCRIPTION
Some of the built in implementations actually do that already.