### PR TITLE
Test without pip build isolation

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -1355,7 +1355,7 @@ class TestBashGlobal(TestBash):
             self.sh.run_command("export PATH=$PATH:./bin")
             self.sh.run_command("export PYTHONPATH=.:$PYTHONPATH")
             test_package = os.path.join(TEST_DIR, "test_package")
-            command = "pip install {} --target .".format(test_package)
+            command = "pip install --no-build-isolation {} --target .".format(test_package)
             if not wheel:
                 command += " --no-binary :all:"
                 if sys.platform == "darwin":


### PR DESCRIPTION
This allows keeping running the tests in an offline environment with pip 23.1.2.

Without this, we get:

    ======================================================================
    FAIL: test_console_script_module (test.test.TestBashGlobal.test_console_script_module)
    Test completing a console_script for a module.
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/builddir/build/BUILD/argcomplete-2.0.0/test/test.py", line 1293, in test_console_script_module
        self._test_console_script()
      File "/builddir/build/BUILD/argcomplete-2.0.0/test/test.py", line 1283, in _test_console_script
        self.assertEqual(self.sh.run_command('echo $?'), '0\r\n', install_output)
    AssertionError: '1\r\n' != '0\r\n'
    - 1
    + 0
     : Processing /builddir/build/BUILD/argcomplete-2.0.0/test/test_package
      Installing build dependencies ... [?25l- \ | / - error
      error: subprocess-exited-with-error
      
      × pip subprocess to install build dependencies did not run successfully.
      │ exit code: 1
      ╰─> [7 lines of output]
          WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f5a0e412190>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/setuptools/
          WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f5a0ca518d0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/setuptools/
          WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f5a0ca9fe90>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/setuptools/
          WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f5a0e61cd10>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/setuptools/
          WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7f5a0e17e290>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/setuptools/
          ERROR: Could not find a version that satisfies the requirement setuptools>=40.8.0 (from versions: none)
          ERROR: No matching distribution found for setuptools>=40.8.0
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: subprocess-exited-with-error

    × pip subprocess to install build dependencies did not run successfully.
    │ exit code: 1
    ╰─> See above for output.

    note: This error originates from a subprocess, and is likely not a problem with pip.