### PR TITLE
Use ` as escape character in PowerShell

### DIFF
--- a/argcomplete/finders.py
+++ b/argcomplete/finders.py
@@ -520,7 +520,11 @@ class CompletionFinder(object):
             completions = [c.replace("'", r"'\''") for c in completions]
 
         # PowerShell uses ` as escape character.
-        escape_char = '`' if os.getenv('PSModulePath') else "\\"
+        if os.getenv('PSModulePath'):
+            escape_char = '`'
+            special_chars = special_chars.replace('`', '')
+        else:
+            escape_char = "\\"
         for char in special_chars:
             completions = [c.replace(char, escape_char + char) for c in completions]
 

--- a/argcomplete/finders.py
+++ b/argcomplete/finders.py
@@ -519,8 +519,10 @@ class CompletionFinder(object):
             special_chars = ""
             completions = [c.replace("'", r"'\''") for c in completions]
 
+        # PowerShell uses ` as escape character.
+        escape_char = '`' if os.getenv('PSModulePath') else "\\"
         for char in special_chars:
-            completions = [c.replace(char, "\\" + char) for c in completions]
+            completions = [c.replace(char, escape_char + char) for c in completions]
 
         if self.append_space:
             # Similar functionality in bash was previously turned off by supplying the "-o nospace" option to complete.


### PR DESCRIPTION
Related issue: https://github.com/Azure/azure-cli/issues/26526

Argcomplete escape the special_chars with `\` when get completion.
The result is incorrect on PowerShell.
For example. space will be converted to `\ `, but it should be `` `  ``