### PR TITLE
Ensure Python 3.7 compatibility in check_console_script

### DIFF
--- a/argcomplete/_check_console_script.py
+++ b/argcomplete/_check_console_script.py
@@ -16,12 +16,15 @@ import sys
 
 try:
     from importlib.metadata import entry_points as importlib_entry_points
+    from importlib.metadata import EntryPoint
     use_entry_points_backport = False
 except ImportError:
     from importlib_metadata import entry_points as importlib_entry_points  # type:ignore
+    from importlib_metadata import EntryPoint # type:ignore
     use_entry_points_backport = True
 
 from ._check_module import ArgcompleteMarkerNotFound, find
+from typing import Iterable
 
 
 def main():
@@ -32,15 +35,15 @@ def main():
     # assuming it is actually a console script.
     name = os.path.basename(script_path)
 
-    entry_points = importlib_entry_points()
+    entry_points : Iterable[EntryPoint] = importlib_entry_points() # type:ignore
 
     # The importlib_metadata backport returns a tuple of entry point objects
     # whereas the official library returns a SelectableGroups object
     if not use_entry_points_backport:
-        entry_points = entry_points["console_scripts"]
+        entry_points = entry_points["console_scripts"] # type:ignore
 
     entry_points = [ep for ep in entry_points \
-            if ep.name == name and ep.group == "console_scripts" ]
+            if ep.name == name and ep.group == "console_scripts" ] # type:ignore
 
     if not entry_points:
         raise ArgcompleteMarkerNotFound("no entry point found matching script")

--- a/argcomplete/_check_console_script.py
+++ b/argcomplete/_check_console_script.py
@@ -16,8 +16,10 @@ import sys
 
 try:
     from importlib.metadata import entry_points as importlib_entry_points
+    use_entry_points_backport = False
 except ImportError:
     from importlib_metadata import entry_points as importlib_entry_points  # type:ignore
+    use_entry_points_backport = True
 
 from ._check_module import ArgcompleteMarkerNotFound, find
 
@@ -29,7 +31,17 @@ def main():
     # Find the module and function names that correspond to this
     # assuming it is actually a console script.
     name = os.path.basename(script_path)
-    entry_points = [ep for ep in importlib_entry_points()["console_scripts"] if ep.name == name]
+
+    entry_points = importlib_entry_points()
+
+    # The importlib_metadata backport returns a tuple of entry point objects
+    # whereas the official library returns a SelectableGroups object
+    if not use_entry_points_backport:
+        entry_points = entry_points["console_scripts"]
+
+    entry_points = [ep for ep in entry_points \
+            if ep.name == name and ep.group == "console_scripts" ]
+
     if not entry_points:
         raise ArgcompleteMarkerNotFound("no entry point found matching script")
     entry_point = entry_points[0]


### PR DESCRIPTION
The importlib backport, `importlib_metadata`, returns a tuple of entry points instead of a dictionary keyed by entry group. This inconsistency caused a KeyError exception to be thrown. To resolve this issue, the script has been adjusted to maintain compatibility with Python 3.7, as specified in `setup.py`.

May resolve #435.