### PR TITLE
Drop shebang from argcomplete/shell_integration.py

### DIFF
--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2012-2023, Andrey Kislyuk and argcomplete contributors. Licensed under the terms of the
 # `Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>`_. Distribution of the LICENSE and NOTICE
 # files with source copies of this package and derivative works is **REQUIRED** as specified by the Apache License.


### PR DESCRIPTION
Since this file does not have executable permissions and does not have a main routine, the shebang line is not useful.