### PR TITLE
Ensure Python 3.12+ compatibility in check_console_script

### DIFF
--- a/argcomplete/_check_console_script.py
+++ b/argcomplete/_check_console_script.py
@@ -39,7 +39,8 @@ def main():
 
     # The importlib_metadata backport returns a tuple of entry point objects
     # whereas the official library returns a SelectableGroups object
-    if not use_entry_points_backport:
+    # Python 3.12+ behaves like the importlib_metadata backport
+    if not use_entry_points_backport and sys.version_info < (3, 12):
         entry_points = entry_points["console_scripts"] # type:ignore
 
     entry_points = [ep for ep in entry_points \


### PR DESCRIPTION
In f4d046c0cec1dab17f65853442b1da7d341e2915 an assumption was made (correct at the time), that only the importlib.metadata backport, `importlib_metadata`, returns a tuple of entry points.

However, importlib.metadata in Python 3.12+ behaves the same.

This caused a KeyError exception to be thrown on Python 3.12, as reported repeatedly be testers of Fedora Linux 39 in:

https://bugzilla.redhat.com/show_bug.cgi?id=2231593

This change adjusts the conditional used in check_console_script to assume both the backport and Python 3.12+ return a tuple.

While not obvious from the test failures output,
this change also fixes the following TestBashGlobal tests failures:

 - test_console_script_module
 - test_console_script_module_wheel
 - test_console_script_package
 - test_console_script_package_wheel

For the reference, the failures looked like this:

    FAIL: test_console_script_module (__main__.TestBashGlobal.test_console_script_module)
    Test completing a console_script for a module.
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File ".../argcomplete/test/test.py", line 1376, in test_console_script_module
        self._test_console_script()
      File ".../argcomplete/test/test.py", line 1370, in _test_console_script
        self.assertEqual(self.sh.run_command(command), "arg\r\n")
    AssertionError: "usage: test-module [-h] {arg}\r\ntest-mo[66 chars]\r\n" != 'arg\r\n'
    + arg
    - usage: test-module [-h] {arg}
    - test-module: error: argument arg: invalid choice: 'a' (choose from 'arg')

Fixes https://github.com/kislyuk/argcomplete/issues/440