### PR TITLE
Add support for Python 3.12 and drop EOL 3.6 and 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: ${{matrix.python-version}}
+        allow-prereleases: true
     - name: Install CI dependencies
       run: |
         [[ $(uname) == Linux ]] && sudo apt-get install --yes rpm tcsh fish zsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/argcomplete/_check_console_script.py
+++ b/argcomplete/_check_console_script.py
@@ -14,14 +14,8 @@ Intended to be invoked by argcomplete's global completion function.
 import os
 import sys
 
-try:
-    from importlib.metadata import entry_points as importlib_entry_points
-    from importlib.metadata import EntryPoint
-    use_entry_points_backport = False
-except ImportError:
-    from importlib_metadata import entry_points as importlib_entry_points  # type:ignore
-    from importlib_metadata import EntryPoint # type:ignore
-    use_entry_points_backport = True
+from importlib.metadata import entry_points as importlib_entry_points
+from importlib.metadata import EntryPoint
 
 from ._check_module import ArgcompleteMarkerNotFound, find
 from typing import Iterable
@@ -37,10 +31,9 @@ def main():
 
     entry_points : Iterable[EntryPoint] = importlib_entry_points() # type:ignore
 
-    # The importlib_metadata backport returns a tuple of entry point objects
-    # whereas the official library returns a SelectableGroups object
-    # Python 3.12+ behaves like the importlib_metadata backport
-    if not use_entry_points_backport and sys.version_info < (3, 12):
+    # Python 3.12+ returns a tuple of entry point objects
+    # whereas <=3.11 returns a SelectableGroups object
+    if sys.version_info < (3, 12):
         entry_points = entry_points["console_scripts"] # type:ignore
 
     entry_points = [ep for ep in entry_points \

--- a/argcomplete/_check_module.py
+++ b/argcomplete/_check_module.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     import typing as t
     from collections import namedtuple
-    from imp import find_module
+    from imp import find_module  # type:ignore
 
     ModuleSpec = namedtuple("ModuleSpec", ["origin", "has_location", "submodule_search_locations"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "argcomplete"
 description = "Bash tab completion for argparse"
 readme = "README.rst"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 license = { text = "Apache Software License" }
 authors = [{ name = "Andrey Kislyuk"}, {email = "kislyuk@gmail.com" }]
 maintainers = []
@@ -33,7 +33,6 @@ classifiers = [
   "Topic :: System :: Shells",
   "Topic :: Terminals",
 ]
-dependencies = ["importlib-metadata >= 0.23, < 7; python_version < '3.8'"]
 
 [project.optional-dependencies]
 test = ["coverage", "pexpect", "wheel", "ruff", "mypy"]

--- a/test/test.py
+++ b/test/test.py
@@ -1370,25 +1370,21 @@ class TestBashGlobal(TestBash):
             self.assertEqual(self.sh.run_command(command), "arg\r\n")
 
     @unittest.skipIf(os.uname()[0] == "Darwin", "Skip test that fails on MacOS")
-    @unittest.skipIf(sys.version_info < (3, 8), "Skip test that fails on Python 3.7 with importlib_metadata > 4")
     def test_console_script_module(self):
         """Test completing a console_script for a module."""
         self._test_console_script()
 
     @unittest.skipIf(os.uname()[0] == "Darwin", "Skip test that fails on MacOS")
-    @unittest.skipIf(sys.version_info < (3, 8), "Skip test that fails on Python 3.7 with importlib_metadata > 4")
     def test_console_script_package(self):
         """Test completing a console_script for a package."""
         self._test_console_script(package=True)
 
     @unittest.skipIf(os.uname()[0] == "Darwin", "Skip test that fails on MacOS")
-    @unittest.skipIf(sys.version_info < (3, 8), "Skip test that fails on Python 3.7 with importlib_metadata > 4")
     def test_console_script_module_wheel(self):
         """Test completing a console_script for a module from a wheel."""
         self._test_console_script(wheel=True)
 
     @unittest.skipIf(os.uname()[0] == "Darwin", "Skip test that fails on MacOS")
-    @unittest.skipIf(sys.version_info < (3, 8), "Skip test that fails on Python 3.7 with importlib_metadata > 4")
     def test_console_script_package_wheel(self):
         """Test completing a console_script for a package from a wheel."""
         self._test_console_script(package=True, wheel=True)


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/
