### PR TITLE
zsh: Allow to use external script.

### DIFF
--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -32,6 +32,7 @@ __python_argcomplete_run_inner() {
 
 _python_argcomplete%(function_suffix)s() {
     local IFS=$'\013'
+    local script="%(argcomplete_script)s"
     if [[ -n "${ZSH_VERSION-}" ]]; then
         local completions
         completions=($(IFS="$IFS" \
@@ -40,7 +41,7 @@ _python_argcomplete%(function_suffix)s() {
             _ARGCOMPLETE=1 \
             _ARGCOMPLETE_SHELL="zsh" \
             _ARGCOMPLETE_SUPPRESS_SPACE=1 \
-            __python_argcomplete_run "${words[1]}") )
+            __python_argcomplete_run ${script:-${words[1]}}))
         _describe "${words[1]}" completions -o nosort
     else
         local SUPPRESS_SPACE=0
@@ -55,7 +56,7 @@ _python_argcomplete%(function_suffix)s() {
             _ARGCOMPLETE=1 \
             _ARGCOMPLETE_SHELL="bash" \
             _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
-            __python_argcomplete_run "%(argcomplete_script)s"))
+            __python_argcomplete_run ${script:-$1}))
         if [[ $? != 0 ]]; then
             unset COMPREPLY
         elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
@@ -144,7 +145,7 @@ def shellcode(executables, use_defaults=True, shell="bash", complete_arguments=N
         if script:
             function_suffix = "_" + script
         else:
-            script = "$1"
+            script = ""
             function_suffix = ""
         code = bashcode % dict(
             complete_opts=complete_options,


### PR DESCRIPTION
This patch add support external script for zsh:
Example:

complete_func() {
    echo "complete func called" > done.txt
}

eval "$(register-python-argcomplete -e complete_func arc_test)"

Bug: #452