### PR TITLE
Fix missing checkout steps on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,10 @@ jobs:
   black:
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - uses: psf/black@stable
   isort:
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - uses: isort/isort-action@v1.1.0

--- a/argcomplete/_check_console_script.py
+++ b/argcomplete/_check_console_script.py
@@ -13,12 +13,11 @@ Intended to be invoked by argcomplete's global completion function.
 """
 import os
 import sys
-
-from importlib.metadata import entry_points as importlib_entry_points
 from importlib.metadata import EntryPoint
+from importlib.metadata import entry_points as importlib_entry_points
+from typing import Iterable
 
 from ._check_module import ArgcompleteMarkerNotFound, find
-from typing import Iterable
 
 
 def main():
@@ -29,15 +28,14 @@ def main():
     # assuming it is actually a console script.
     name = os.path.basename(script_path)
 
-    entry_points : Iterable[EntryPoint] = importlib_entry_points() # type:ignore
+    entry_points: Iterable[EntryPoint] = importlib_entry_points()  # type:ignore
 
     # Python 3.12+ returns a tuple of entry point objects
     # whereas <=3.11 returns a SelectableGroups object
     if sys.version_info < (3, 12):
-        entry_points = entry_points["console_scripts"] # type:ignore
+        entry_points = entry_points["console_scripts"]  # type:ignore
 
-    entry_points = [ep for ep in entry_points \
-            if ep.name == name and ep.group == "console_scripts" ] # type:ignore
+    entry_points = [ep for ep in entry_points if ep.name == name and ep.group == "console_scripts"]  # type:ignore
 
     if not entry_points:
         raise ArgcompleteMarkerNotFound("no entry point found matching script")


### PR DESCRIPTION
Hello @kislyuk,

Thank you for your work on this great project! 🙇🏻‍♂️ 

Currently, `black` and `isort` [do nothing](https://github.com/kislyuk/argcomplete/actions/runs/6843221086/job/18605571800#step:2:43) on CI due to lack of the source code to analyze. To fix that, corresponding checkout steps need to be added.

These changes also apply `black`/`isort` to the code.

Best regards!