### PR TITLE
Fix zsh global install

### DIFF
--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -1,9 +1,14 @@
-#compdef -P *
+#compdef -default-
 
 # Copyright 2012-2023, Andrey Kislyuk and argcomplete contributors.
 # Licensed under the Apache License. See https://github.com/kislyuk/argcomplete for more info.
 
 # Note: both the leading underscore in the name of this file and the first line (compdef) are required by zsh
+
+# In zsh, this file is autoloaded and used as the default completer (_default).
+# There are many other special contexts we don't want to override
+# (as would be the case with `#compdef -P *`).
+# https://zsh.sourceforge.io/Doc/Release/Completion-System.html
 
 # Copy of __expand_tilde_by_ref from bash-completion
 # ZSH implementation added
@@ -237,8 +242,7 @@ if [[ -z "${ZSH_VERSION-}" ]]; then
     complete -o default -o bashdefault -D -F _python_argcomplete_global
 else
     autoload is-at-least
-    # Replace only the default completer (_default).
-    # There are many other special contexts we don't want to override.
-    # https://zsh.sourceforge.io/Doc/Release/Completion-System.html
-    compdef _python_argcomplete_global -default-
+    # The comment at the top of this file causes zsh to invoke this script directly,
+    # so we must explicitly call the global completion function.
+    _python_argcomplete_global
 fi

--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -241,7 +241,9 @@ _python_argcomplete_global() {
 if [[ -z "${ZSH_VERSION-}" ]]; then
     complete -o default -o bashdefault -D -F _python_argcomplete_global
 else
-    autoload is-at-least
+    # -Uz is recommended for the use of functions supplied with the zsh distribution.
+    # https://unix.stackexchange.com/a/214306
+    autoload -Uz is-at-least
     # The comment at the top of this file causes zsh to invoke this script directly,
     # so we must explicitly call the global completion function.
     _python_argcomplete_global

--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -115,6 +115,7 @@ __python_argcomplete_which() {
 }
 
 _python_argcomplete_global() {
+
     if [[ -n "${ZSH_VERSION-}" ]]; then
         # Store result of a regex match in the
         # BASH_REMATCH variable rather than MATCH
@@ -236,8 +237,8 @@ if [[ -z "${ZSH_VERSION-}" ]]; then
     complete -o default -o bashdefault -D -F _python_argcomplete_global
 else
     autoload is-at-least
-    # Set a hook for argcomplete to be called first if no other completers are defined for the given command.
-    # "compdef _python_argcomplete_global -P *" overrides other special contexts that we want to preserve:
+    # Replace only the default completer (_default).
+    # There are many other special contexts we don't want to override.
     # https://zsh.sourceforge.io/Doc/Release/Completion-System.html
-    compdef _python_argcomplete_global -first-
+    compdef _python_argcomplete_global -default-
 fi


### PR DESCRIPTION
This fixes zsh global completion breakage introduced in #463, and updates the test to use a similar method as `activate-global-python-argcomplete` for zsh.

The zsh global completion script was previously mixing paradigms; it seems that you are supposed to use a file with a `#compdef` comment which is autoloaded, **or** manually call `compdef` yourself. I've updated this to only use the `#compdef` comment, but it does feel like everything would be simpler if we went the other way and sourced the file directly as we do with bash. The only catch with that is we would probably have to append this to `~/.zshrc` instead of `~/.zshenv` since we need `compdef` to be available, and it seems undesirable to `autoload compdef` on the user's behalf.