### PR TITLE
Allow explicit zsh global completion activation

### DIFF
--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -244,7 +244,17 @@ else
     # -Uz is recommended for the use of functions supplied with the zsh distribution.
     # https://unix.stackexchange.com/a/214306
     autoload -Uz is-at-least
-    # The comment at the top of this file causes zsh to invoke this script directly,
+    # If this is being implicitly loaded because we placed it on fpath,
+    # the comment at the top of this file causes zsh to invoke this script directly,
     # so we must explicitly call the global completion function.
-    _python_argcomplete_global
+    # Note $service should only ever be -default- because the comment at the top
+    # registers this script as the default completer (#compdef -default-).
+    if [[ $service == -default- ]]; then
+        _python_argcomplete_global
+    fi
+    # If this has been executed directly (e.g. `eval "$(activate-global-python-argcomplete --dest=-)"`)
+    # we need to explicitly call compdef to register the completion function.
+    # If we have been implicitly loaded, we still call compdef as a slight optimisation
+    # (there is no need to execute any top-level code more than once).
+    compdef _python_argcomplete_global -default-
 fi

--- a/test/test.py
+++ b/test/test.py
@@ -1409,11 +1409,13 @@ class TestBashGlobal(TestBash, TestBashZshGlobalBase):
     pass
 
 
-class TestZshGlobal(TestZsh, TestBashZshGlobalBase):
-    # In zsh, the file is not sourced directly;
+class TestZshGlobalExplicit(TestZsh, TestBashZshGlobalBase):
+    pass
+
+
+class TestZshGlobalImplicit(TestZsh, TestBashZshGlobalBase):
+    # In zsh, the file is typically not sourced directly;
     # it is added to fpath and autoloaded by the completion system.
-    # Running `eval "$(activate-global-python-argcomplete --dest=-)"`
-    # as in bash does *not* work in zsh!
     zsh_fpath = os.path.join(os.path.abspath(os.path.dirname(argcomplete.__file__)), "bash_completion.d")
     init_cmd = f'fpath=( {zsh_fpath} "${{fpath[@]}}" ); autoload compinit; compinit -u'
     install_cmd = None


### PR DESCRIPTION
This repairs explicit global completion activation in zsh which was removed in #466.

I find this to be a useful feature if only for testing without needing to modify my local environment. It also allows users to add `eval "$(activate-global-python-argcomplete --dest=-)"` to their `~/.zshrc` file if they would prefer to dynamically get the global completion script every time they start their shell.

The tests now test both methods, though running every test case for both activation methods is likely overkill and the tests could be refactored to only run one basic test for one of them.