### PR TITLE
Lazy completion loading for Zsh

### DIFF
--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -5,7 +5,7 @@
 
 from shlex import quote
 
-bashcode = r"""
+bashcode = r"""#compdef %(executables)s
 # Run something, muting output or redirecting it to the debug stream
 # depending on the value of _ARC_DEBUG.
 # If ARGCOMPLETE_USE_TEMPFILES is set, use tempfiles for IPC.
@@ -76,7 +76,11 @@ if [[ -z "${ZSH_VERSION-}" ]]; then
     complete %(complete_opts)s -F _python_argcomplete%(function_suffix)s %(executables)s
 else
     autoload is-at-least
-    compdef _python_argcomplete%(function_suffix)s %(executables)s
+    if [[ $zsh_eval_context == *func ]]; then
+        _python_argcomplete%(function_suffix)s "$@"
+    else
+        compdef _python_argcomplete%(function_suffix)s %(executables)s
+    fi
 fi
 """
 

--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -75,6 +75,10 @@ _python_argcomplete%(function_suffix)s() {
 if [[ -z "${ZSH_VERSION-}" ]]; then
     complete %(complete_opts)s -F _python_argcomplete%(function_suffix)s %(executables)s
 else
+    # When called by the Zsh completion system, this will end with
+    # "loadautofunc" when initially autoloaded and "shfunc" later on, otherwise,
+    # the script was "eval"-ed so use "compdef" to register it with the
+    # completion system
     autoload is-at-least
     if [[ $zsh_eval_context == *func ]]; then
         _python_argcomplete%(function_suffix)s "$@"


### PR DESCRIPTION
You can simply save the completion script into a directory in the `$fpath` and it will work, the Homebrew formula for pipx already does that, but it doesn't work without this change

Fixes #473