### PR TITLE
Fix path to pexpect's bashrc

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -73,7 +73,7 @@ def _repl_sh(command, args, non_printable_insert):
 
 
 def bash_repl(command="bash"):
-    bashrc = os.path.join(os.path.dirname(pexpect.__file__), "replwrap", "bashrc.sh")
+    bashrc = os.path.join(os.path.dirname(pexpect.__file__), "bashrc.sh")
     sh = _repl_sh(command, ["--rcfile", bashrc], non_printable_insert="\\[\\]")
     return sh
 


### PR DESCRIPTION
Fix path to pexpect's bashrc, to make tests more reliable.  The path was changed in 46e6e7509fa2ab888b51d397658f59841d0c0917 to `replwrap/bashrc.sh` inside pexpect package; however, FWICS no such directory ever existed and the bashrc file was always directly inside the package directory.

Without this change, pexpect's bashrc is not loaded and tests fail when user's bashrc results in a long prompt.  In my case, they failed on a system with a 12-character hostname (and passed on a system with a 6-character hostname).