### PR TITLE
No stdin for python calls from bash completion functions

### DIFF
--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -46,9 +46,9 @@ __python_argcomplete_run() {
 
 __python_argcomplete_run_inner() {
     if [[ -z "${_ARC_DEBUG-}" ]]; then
-        "$@" 8>&1 9>&2 1>/dev/null 2>&1
+        "$@" 8>&1 9>&2 1>/dev/null 2>&1 </dev/null
     else
-        "$@" 8>&1 9>&2 1>&9 2>&1
+        "$@" 8>&1 9>&2 1>&9 2>&1 </dev/null
     fi
 }
 

--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -24,9 +24,9 @@ __python_argcomplete_run() {
 
 __python_argcomplete_run_inner() {
     if [[ -z "${_ARC_DEBUG-}" ]]; then
-        "$@" 8>&1 9>&2 1>/dev/null 2>&1
+        "$@" 8>&1 9>&2 1>/dev/null 2>&1 </dev/null
     else
-        "$@" 8>&1 9>&2 1>&9 2>&1
+        "$@" 8>&1 9>&2 1>&9 2>&1 </dev/null
     fi
 }
 

--- a/test/stuck
+++ b/test/stuck
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
+from sys import argv
+
+if argv[1:] != ["no-input"]:
+    input()

--- a/test/test.py
+++ b/test/test.py
@@ -1348,6 +1348,10 @@ class TestBashZshGlobalBase(TestBashZshBase):
         self.sh.run_command("cd " + TEST_DIR)
         self.assertEqual(self.sh.run_command("python3 ./pro\tbasic f\t"), "foo\r\n")
 
+    def test_python_stuck(self):
+        self.sh.run_command("cd " + TEST_DIR)
+        self.sh.run_command("python3 ./stuck no\t-input")
+
     def test_python_not_executable(self):
         """Test completing a script that cannot be run directly."""
         prog = os.path.join(TEST_DIR, "prog")


### PR DESCRIPTION
Prevents usage of stdin by (python) executables that are called during completion generation. This prevents the completion locking up the entire shell when the python script is broken i.e. it enters an interactive mode (REPL) instead of generating the completions, as expected.

This lockup can be provoked by having a script marked as compatible, but read `stdin` (& wait) for some reason e.g. due to REPL - I've added a corresponding test.