### PR TITLE
Localize shell variable REPLY to avoid overwriting users' value

### DIFF
--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -76,6 +76,7 @@ __python_argcomplete_scan_head() {
     local file="$1"
     local target="$2"
 
+    local REPLY
     if [[ -n "${ZSH_VERSION-}" ]]; then
         read -r -k 1024 -u 0 < "$file";
     else


### PR DESCRIPTION
The shell function `__python_argcomplete_scan_head` in the completion setting (`argcomplete/bash_completion.d/_python-argcomplete`) uses the `read` builtin without specifying variable names. This stores the `read` result in the shell variable `REPLY`. Then, `__python_argcomplete_scan_head` checks the value of `REPLY`. A problem is that this will clobber the users' values of the global shell variable `REPLY` on an attempt of completion. We should declare the `REPLY` as a local variable in the shell function `__python_argcomplete_scan_head`.
