### PR TITLE
use interactive shells and bind to work around issue in bash

### DIFF
--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -59,13 +59,17 @@ class FilesCompleter(BaseCompleter):
         completion = []
         if self.allowednames:
             if self.directories:
-                files = _call(["bash", "-c", "compgen -A directory -- '{p}'".format(p=prefix)])
+                # Using '-i' and 'bind' in this and the following commands is a workaround to a bug in bash
+                # that was fixed in bash 3.5 but affects older versions. Environment variables are not treated
+                # correctly in older versions and calling bind makes them available. For details, see
+                # https://savannah.gnu.org/support/index.php?111125
+                files = _call(["bash", "-ic", "bind; compgen -A directory -- '{p}'".format(p=prefix)])
                 completion += [f + "/" for f in files]
             for x in self.allowednames:
-                completion += _call(["bash", "-c", "compgen -A file -X '!*.{0}' -- '{p}'".format(x, p=prefix)])
+                completion += _call(["bash", "-ic", "bind; compgen -A file -X '!*.{0}' -- '{p}'".format(x, p=prefix)])
         else:
-            completion += _call(["bash", "-c", "compgen -A file -- '{p}'".format(p=prefix)])
-            anticomp = _call(["bash", "-c", "compgen -A directory -- '{p}'".format(p=prefix)])
+            completion += _call(["bash", "-ic", "bind; compgen -A file -- '{p}'".format(p=prefix)])
+            anticomp = _call(["bash", "-ic", "bind; compgen -A directory -- '{p}'".format(p=prefix)])
             completion = list(set(completion) - set(anticomp))
 
             if self.directories:

--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -60,7 +60,7 @@ class FilesCompleter(BaseCompleter):
         if self.allowednames:
             if self.directories:
                 # Using '-i' and 'bind' in this and the following commands is a workaround to a bug in bash
-                # that was fixed in bash 3.5 but affects older versions. Environment variables are not treated
+                # that was fixed in bash 5.3 but affects older versions. Environment variables are not treated
                 # correctly in older versions and calling bind makes them available. For details, see
                 # https://savannah.gnu.org/support/index.php?111125
                 files = _call(["bash", "-ic", "bind; compgen -A directory -- '{p}'".format(p=prefix)])

--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -59,17 +59,17 @@ class FilesCompleter(BaseCompleter):
         completion = []
         if self.allowednames:
             if self.directories:
-                # Using '-i' and 'bind' in this and the following commands is a workaround to a bug in bash
+                # Using 'bind' in this and the following commands is a workaround to a bug in bash
                 # that was fixed in bash 5.3 but affects older versions. Environment variables are not treated
                 # correctly in older versions and calling bind makes them available. For details, see
                 # https://savannah.gnu.org/support/index.php?111125
-                files = _call(["bash", "-ic", "bind; compgen -A directory -- '{p}'".format(p=prefix)])
+                files = _call(["bash", "-c", "bind; compgen -A directory -- '{p}'".format(p=prefix)], stderr=subprocess.DEVNULL)
                 completion += [f + "/" for f in files]
             for x in self.allowednames:
-                completion += _call(["bash", "-ic", "bind; compgen -A file -X '!*.{0}' -- '{p}'".format(x, p=prefix)])
+                completion += _call(["bash", "-c", "bind; compgen -A file -X '!*.{0}' -- '{p}'".format(x, p=prefix)], stderr=subprocess.DEVNULL)
         else:
-            completion += _call(["bash", "-ic", "bind; compgen -A file -- '{p}'".format(p=prefix)])
-            anticomp = _call(["bash", "-ic", "bind; compgen -A directory -- '{p}'".format(p=prefix)])
+            completion += _call(["bash", "-c", "bind; compgen -A file -- '{p}'".format(p=prefix)], stderr=subprocess.DEVNULL)
+            anticomp = _call(["bash", "-c", "bind; compgen -A directory -- '{p}'".format(p=prefix)], stderr=subprocess.DEVNULL)
             completion = list(set(completion) - set(anticomp))
 
             if self.directories:


### PR DESCRIPTION
This is a workaround to #502 where environment variables in file names are not completed. The issue is that calling `compgen` in a nested bash did not recognize the environment variables. It looks like this is a bug that was fixed in bash 5.3 but it still affects earlier versions (https://savannah.gnu.org/support/index.php?111125) For those earlier version, calling `bind` before the call to `compgen` forces the necessary initialization.

This works with a normal shell, but produces a warning `line editing not enabled` because bind is meant for interactive contexts. Using `-i` to turn the nested shell into an interactive shell avoids the warning. An alternative would be to pipe the warning to `/dev/null` instead.