### PR TITLE
Fix issue #507

### DIFF
--- a/argcomplete/packages/_argparse.py
+++ b/argcomplete/packages/_argparse.py
@@ -162,6 +162,8 @@ class IntrospectiveArgumentParser(ArgumentParser):
         def consume_optional(start_index):
             # get the optional identified at this index
             option_tuple = option_string_indices[start_index]
+            if isinstance(option_tuple, list):  # Python 3.12.7+
+                option_tuple = option_tuple[0]
             if len(option_tuple) == 3:
                 action, option_string, explicit_arg = option_tuple
             else:  # Python 3.11.9+, 3.12.3+, 3.13+


### PR DESCRIPTION
In Python 3.13 and 3.12.7, the behavior of `_parse_optional` has changed to return a list of tuples: https://github.com/python/cpython/pull/124631
This change would break the optional argument parsing of this library.

This PR will detect this behavior and return the proper format accordingly.
This PR resolves issue #507.

Cross ref: https://github.com/omni-us/jsonargparse/pull/591#pullrequestreview-2350465411