### PR TITLE
Update shell_integration.py to support spaces in script file path.

### DIFF
--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -166,7 +166,8 @@ def shellcode(executables, use_defaults=True, shell="bash", complete_arguments=N
         executables_list = " ".join(quoted_executables)
         script = argcomplete_script
         if script:
-            function_suffix = "_" + script
+            # If the script path contain a space, this would generate an invalid function name.
+            function_suffix = "_" + script.replace(" ", "_SPACE_")
         else:
             script = ""
             function_suffix = ""


### PR DESCRIPTION
Currently, any space in a script file path will result in an invalid shell code when calling shellcode(..., argcomplete_script=<path containing a space>). Replacing any space with "_SPACE_" solves this issue.