### PR TITLE
Fix completion when wordbreak is first character

### DIFF
--- a/argcomplete/finders.py
+++ b/argcomplete/finders.py
@@ -515,7 +515,7 @@ class CompletionFinder(object):
             # Bash mangles completions which contain characters in COMP_WORDBREAKS.
             # This workaround has the same effect as __ltrim_colon_completions in bash_completion
             # (extended to characters other than the colon).
-            if last_wordbreak_pos:
+            if last_wordbreak_pos is not None:
                 completions = [c[last_wordbreak_pos + 1 :] for c in completions]
             special_chars += "();<>|&!`$* \t\n\"'"
         elif cword_prequote == '"':

--- a/argcomplete/packages/_shlex.py
+++ b/argcomplete/packages/_shlex.py
@@ -177,6 +177,9 @@ class shlex:
                 elif self.whitespace_split:
                     self.token = nextchar
                     self.state = 'a'
+                    # Modified by argcomplete: Record last wordbreak position
+                    if nextchar in self.wordbreaks:
+                        self.last_wordbreak_pos = len(self.token) - 1
                 else:
                     self.token = nextchar
                     if self.token or (self.posix and quoted):

--- a/test/test.py
+++ b/test/test.py
@@ -1041,10 +1041,12 @@ class TestSplitLine(unittest.TestCase):
 
     def test_last_wordbreak_pos(self):
         self.assertEqual(self.wordbreak("a"), None)
+        self.assertEqual(self.wordbreak("a :b"), 0)
         self.assertEqual(self.wordbreak("a b:c"), 1)
         self.assertEqual(self.wordbreak("a b:c=d"), 3)
         self.assertEqual(self.wordbreak("a b:c=d "), None)
         self.assertEqual(self.wordbreak("a b:c=d e"), None)
+        self.assertEqual(self.wordbreak('":b'), None)
         self.assertEqual(self.wordbreak('"b:c'), None)
         self.assertEqual(self.wordbreak('"b:c=d'), None)
         self.assertEqual(self.wordbreak('"b:c=d"'), None)


### PR DESCRIPTION
When a completion argument starts with a wordbreak character (e.g. "a :b"), argcomplete doesn't properly set `last_wordbreak_pos` and remove the wordbreak character from the results. This causes bash to add an extra wordbreak character (e.g. "a ::b") which then breaks any further completion. This commit properly sets `last_wordbreak_pos` in the _shlex parser, and adds a test case for a leading colon.