### PR TITLE
Improved support statement in README concerning shells and platforms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,18 @@
-argcomplete - Bash/zsh tab completion for argparse
+argcomplete - shell tab completion for argparse
 ==================================================
 *Tab complete all the things!*
 
 Argcomplete provides easy, extensible command line tab completion of arguments for your Python application.
-
-It makes two assumptions:
-
-* You're using bash or zsh as your shell
-* You're using `argparse <http://docs.python.org/3/library/argparse.html>`_ to manage your command line arguments/options
+At least if you're using `argparse <https://docs.python.org/3/library/argparse.html>`_ to manage your command line arguments/options.
 
 Argcomplete is particularly useful if your program has lots of options or subparsers, and if your program can
 dynamically suggest completions for your argument/option values (for example, if the user is browsing resources over
 the network).
+
+Official support is only provided for bash and zsh on Linux and MacOS.
+
+There is limited community-provided support in argcomplete for other shells and platforms, including fish, tcsh, xonsh, powershell, and Windows, please see the
+`contrib <https://github.com/kislyuk/argcomplete/tree/develop/contrib>`_ directory.
 
 Installation
 ------------
@@ -254,12 +255,6 @@ work for zsh as well.
 Python Support
 --------------
 Argcomplete requires Python 3.9+.
-
-Support for other shells
-------------------------
-Argcomplete maintainers provide support only for the bash and zsh shells on Linux and MacOS. For resources related to
-other shells and platforms, including fish, tcsh, xonsh, powershell, and Windows, please see the
-`contrib <https://github.com/kislyuk/argcomplete/tree/develop/contrib>`_ directory.
 
 Common Problems
 ---------------


### PR DESCRIPTION
Currently, the argcomplete README gives the reader the impression that the module will exclusively function with bash and zsh. Only if we read nearly towards the end, we learn that it works with other shells, too.

If developers or end-users just skim over the first paragraph, they might think, okay this is not for me, it doesn't work with my favorite shell, and quit. While in fact it would work.

So I propose to make clear early with which shells argcomplete works. I do understand that you want to also make clear that you don't intend to officially support other shells than bash and zsh. So I tried to put emphasis on this.

I hope both points become clear in the README now. Please let me know what you think.