### PR TITLE
fish: set variable scope to local

### DIFF
--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -94,14 +94,14 @@ complete "%(executable)s" 'p@*@`python-argcomplete-tcsh "%(argcomplete_script)s"
 
 fishcode = r"""
 function __fish_%(function_name)s_complete
-    set -x _ARGCOMPLETE 1
-    set -x _ARGCOMPLETE_DFS \t
-    set -x _ARGCOMPLETE_IFS \n
-    set -x _ARGCOMPLETE_SUPPRESS_SPACE 1
-    set -x _ARGCOMPLETE_SHELL fish
-    set -x COMP_LINE (commandline -p)
-    set -x COMP_POINT (string length (commandline -cp))
-    set -x COMP_TYPE
+    set -lx _ARGCOMPLETE 1
+    set -lx _ARGCOMPLETE_DFS \t
+    set -lx _ARGCOMPLETE_IFS \n
+    set -lx _ARGCOMPLETE_SUPPRESS_SPACE 1
+    set -lx _ARGCOMPLETE_SHELL fish
+    set -lx COMP_LINE (commandline -p)
+    set -lx COMP_POINT (string length (commandline -cp))
+    set -lx COMP_TYPE
     if set -q _ARC_DEBUG
         %(argcomplete_script)s 8>&1 9>&2 1>&9 2>&1
     else


### PR DESCRIPTION
Small improvement to the fish completion script: Such variables should be explicitly scoped to local. Otherwise the script could accidentally modify a global variable of the same name.

The variables are still exported to the programs invoked by the function so everything works as before but without a potential undesired side-effect.