### PR TITLE
Only execute Python interpreters

### DIFF
--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -193,7 +193,8 @@ _python_argcomplete_global() {
             if (__python_argcomplete_scan_head_noerr "$SCRIPT_NAME" easy_install \
                 && "${interpreter[@]}" "$(__python_argcomplete_which python-argcomplete-check-easy-install-script)" "$SCRIPT_NAME") >/dev/null 2>&1; then
                 ARGCOMPLETE=1
-            elif __python_argcomplete_run "${interpreter[@]}" -m argcomplete._check_console_script "$SCRIPT_NAME"; then
+            elif ([[ "${interpreter[@]}" == *python* ]] || [[ "${interpreter[@]}" == *pypy* ]])\
+                && __python_argcomplete_run "${interpreter[@]}" -m argcomplete._check_console_script "$SCRIPT_NAME"; then
                 ARGCOMPLETE=1
             fi
         fi


### PR DESCRIPTION
Fixes https://github.com/kislyuk/argcomplete/issues/535

This checks if the interpreter is anything with python or pypy in it.

Thus, avoiding executing e.g. `php -m argcomplete._check_console_script ...` (which succeeds).