### PR TITLE
Add `__all__` to `__init__`

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -11,3 +11,21 @@ from .shell_integration import shellcode
 
 autocomplete = CompletionFinder()
 autocomplete.__doc__ = """ Use this to access argcomplete. See :meth:`argcomplete.CompletionFinder.__call__()`. """
+
+__all__ = [
+    'completers',
+    'ChoicesCompleter',
+    'DirectoriesCompleter',
+    'EnvironCompleter',
+    'FilesCompleter',
+    'SuppressCompleter',
+    'ArgcompleteException',
+    'CompletionFinder',
+    'ExclusiveCompletionFinder',
+    'safe_actions',
+    'debug',
+    'mute_stderr',
+    'warn',
+    'split_line',
+    'shellcode',
+]


### PR DESCRIPTION
Explicit re-exporting avoids `reportPrivateImportUsage` warnings from `pylance`, and its hints to then import from `argcomplete.completers` instead:

https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportPrivateImportUsage.md