### PR TITLE
quote prefix passed to compgen in FilesCompleter

### DIFF
--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -4,6 +4,7 @@
 import argparse
 import os
 import subprocess
+from shlex import quote
 
 
 def _call(*args, **kwargs):
@@ -64,20 +65,22 @@ class FilesCompleter(BaseCompleter):
                 # correctly in older versions and calling bind makes them available. For details, see
                 # https://savannah.gnu.org/support/index.php?111125
                 files = _call(
-                    ["bash", "-c", "bind; compgen -A directory -- '{p}'".format(p=prefix)], stderr=subprocess.DEVNULL
+                    ["bash", "-c", "bind; compgen -A directory -- {p}".format(p=quote(prefix))],
+                    stderr=subprocess.DEVNULL,
                 )
                 completion += [f + "/" for f in files]
             for x in self.allowednames:
                 completion += _call(
-                    ["bash", "-c", "bind; compgen -A file -X '!*.{0}' -- '{p}'".format(x, p=prefix)],
+                    ["bash", "-c", "bind; compgen -A file -X '!*.{0}' -- {p}".format(x, p=quote(prefix))],
                     stderr=subprocess.DEVNULL,
                 )
         else:
             completion += _call(
-                ["bash", "-c", "bind; compgen -A file -- '{p}'".format(p=prefix)], stderr=subprocess.DEVNULL
+                ["bash", "-c", "bind; compgen -A file -- {p}".format(p=quote(prefix))], stderr=subprocess.DEVNULL
             )
             anticomp = _call(
-                ["bash", "-c", "bind; compgen -A directory -- '{p}'".format(p=prefix)], stderr=subprocess.DEVNULL
+                ["bash", "-c", "bind; compgen -A directory -- {p}".format(p=quote(prefix))],
+                stderr=subprocess.DEVNULL,
             )
             completion = list(set(completion) - set(anticomp))
 


### PR DESCRIPTION
FilesCompleter interpolates the prefix into a single-quoted compgen string, so a quote in the completed word breaks out and runs arbitrary shell.