### PR TITLE
escape glob and brace metacharacters in quote_completions

### DIFF
--- a/argcomplete/finders.py
+++ b/argcomplete/finders.py
@@ -527,7 +527,7 @@ class CompletionFinder(object):
             # (extended to characters other than the colon).
             if last_wordbreak_pos is not None:
                 completions = [c[last_wordbreak_pos + 1 :] for c in completions]
-            special_chars += "();<>|&!`$* \t\n\"'"
+            special_chars += "();<>|&!`$*?[]{} \t\n\"'"
         elif cword_prequote == '"':
             special_chars += '"`$!'
 


### PR DESCRIPTION
noticed while reading quote_completions that the unquoted branch escapes \* but not the other expansion metacharacters. bash treats them as the same class:

    $ printf '%q\n' 'data?' 'a{b,c}'
    data\?
    a\{b\,c\}

so a completed filename like data? or {x,--flag} stays literal on the line but gets glob/brace expanded by the shell on execution, changing which files or arguments the command receives. escape ? [ ] { } alongside \* in the unquoted case so completions go in as literal tokens.