### PR TITLE
Expand ~ in DirectoriesCompleter (fixes #529)

### DIFF
--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -104,12 +104,15 @@ class _FilteredFilesCompleter(BaseCompleter):
         """
         Provide completions on prefix
         """
-        target_dir = os.path.dirname(prefix)
+        # Expand a leading "~" so that filesystem operations below work on a
+        # real path (os.listdir("~") would otherwise raise FileNotFoundError).
+        expanded_prefix = os.path.expanduser(prefix)
+        target_dir = os.path.dirname(expanded_prefix)
         try:
             names = os.listdir(target_dir or ".")
         except Exception:
             return  # empty iterator
-        incomplete_part = os.path.basename(prefix)
+        incomplete_part = os.path.basename(expanded_prefix)
         # Iterate on target_dir entries and filter on given predicate
         for name in names:
             if not name.startswith(incomplete_part):

--- a/test/test.py
+++ b/test/test.py
@@ -414,6 +414,44 @@ class TestArgcomplete(unittest.TestCase):
             self.assertEqual(c("def/k"), set([]))
         return
 
+    def test_directory_completion_with_tilde(self):
+        # Regression test for https://github.com/kislyuk/argcomplete/issues/529
+        # "~/<TAB>" should expand the home directory instead of yielding nothing
+        # (os.listdir("~") would otherwise raise FileNotFoundError).
+        completer = DirectoriesCompleter()
+
+        def c(prefix):
+            return set(completer(prefix))
+
+        old_home = os.environ.get("HOME")
+        old_userprofile = os.environ.get("USERPROFILE")
+        with TempDir(prefix="test_dir_tilde", dir=".") as tmp_dir:
+            home = os.path.realpath(tmp_dir)
+            os.environ["HOME"] = home
+            os.environ["USERPROFILE"] = home
+            try:
+                # Create some directories and files (files must be ignored)
+                os.makedirs(os.path.join(home, "abc", "baz"))
+                os.makedirs(os.path.join(home, "abb"))
+                with open(os.path.join(home, "abc1"), "w") as fp:
+                    fp.write("A test")
+                # "~/" lists the home directory
+                self.assertEqual(c("~/"), set([os.path.join(home, "abb") + "/", os.path.join(home, "abc") + "/"]))
+                # "~/ab" filters within the home directory
+                self.assertEqual(c("~/ab"), set([os.path.join(home, "abb") + "/", os.path.join(home, "abc") + "/"]))
+                # "~/abc/" recurses into a subdirectory
+                self.assertEqual(c("~/abc/"), set([os.path.join(home, "abc", "baz") + "/"]))
+            finally:
+                if old_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = old_home
+                if old_userprofile is None:
+                    os.environ.pop("USERPROFILE", None)
+                else:
+                    os.environ["USERPROFILE"] = old_userprofile
+        return
+
     def test_default_completer(self):
         def make_parser():
             parser = ArgumentParser(add_help=False)


### PR DESCRIPTION
## Summary

`DirectoriesCompleter` (and its base `_FilteredFilesCompleter`) yields no
completions for a tilde-prefixed path such as `~/`, so `~/<TAB>` shows nothing
even though the home directory has subdirectories. Reported in #529.

The cause is in `_FilteredFilesCompleter.__call__`: `os.path.dirname("~/")`
returns `"~"`, and `os.listdir("~")` raises `FileNotFoundError` (there is no
literal `~` directory). That exception is swallowed by the surrounding
`except Exception: return`, so the completer silently returns an empty iterator.

## Fix

Expand the prefix with `os.path.expanduser` before splitting and listing, so
the filesystem operations run against the real home directory. This mirrors the
behavior of the bash-backed `FilesCompleter`, whose `compgen` already expands
`~`. Non-tilde prefixes are unaffected (`expanduser` is a no-op for them).

```python
expanded_prefix = os.path.expanduser(prefix)
target_dir = os.path.dirname(expanded_prefix)
...
incomplete_part = os.path.basename(expanded_prefix)
```

## Tests

Added `test_directory_completion_with_tilde` (regression test for #529). It
points `HOME`/`USERPROFILE` at a temp directory so the test is hermetic, then
asserts that `~/`, `~/ab`, and `~/abc/` complete correctly. The test fails on
the unpatched code (empty result) and passes with the fix.

- `python -m unittest test.test.TestArgcomplete` — 36 passed
- `ruff check argcomplete test/test.py` — clean
- `ruff format --check argcomplete/completers.py test/test.py` — clean
- `mypy --install-types --non-interactive argcomplete` — clean

Disclosure: prepared with AI assistance; reviewed and verified locally.
