### PR TITLE
100% type coverage

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -9,5 +9,5 @@ from .io import debug, mute_stderr, warn
 from .lexers import split_line
 from .shell_integration import shellcode
 
-autocomplete = CompletionFinder()
+autocomplete: CompletionFinder = CompletionFinder()
 autocomplete.__doc__ = """ Use this to access argcomplete. See :meth:`argcomplete.CompletionFinder.__call__()`. """

--- a/argcomplete/completers.py
+++ b/argcomplete/completers.py
@@ -4,7 +4,12 @@
 import argparse
 import os
 import subprocess
+from collections.abc import Callable, Generator, Iterable, Mapping
 from shlex import quote
+from typing import Final
+
+
+_Ignored = object
 
 
 def _call(*args, **kwargs):
@@ -23,12 +28,14 @@ class BaseCompleter:
 
     def __call__(
         self, *, prefix: str, action: argparse.Action, parser: argparse.ArgumentParser, parsed_args: argparse.Namespace
-    ) -> None:
+    ) -> Iterable[str]:
         raise NotImplementedError("This method should be implemented by a subclass.")
 
 
 class ChoicesCompleter(BaseCompleter):
-    def __init__(self, choices):
+    choices: Final[Mapping[str, str | bytes]]
+
+    def __init__(self, choices: Mapping[str, str | bytes]) -> None:
         self.choices = choices
 
     def _convert(self, choice):
@@ -36,11 +43,11 @@ class ChoicesCompleter(BaseCompleter):
             choice = str(choice)
         return choice
 
-    def __call__(self, **kwargs):
+    def __call__(self, **kwargs: _Ignored) -> Iterable[str]:
         return (self._convert(c) for c in self.choices)
 
 
-EnvironCompleter = ChoicesCompleter(os.environ)
+EnvironCompleter: Final[ChoicesCompleter] = ChoicesCompleter(os.environ)
 
 
 class FilesCompleter(BaseCompleter):
@@ -48,7 +55,10 @@ class FilesCompleter(BaseCompleter):
     File completer class, optionally takes a list of allowed extensions
     """
 
-    def __init__(self, allowednames=(), directories=True):
+    allowednames: Final[list[str]]
+    directories: Final[bool]
+
+    def __init__(self, allowednames: Iterable[str] | str = (), directories: bool = True) -> None:
         # Fix if someone passes in a string instead of a list
         if isinstance(allowednames, (str, bytes)):
             allowednames = [allowednames]
@@ -56,8 +66,8 @@ class FilesCompleter(BaseCompleter):
         self.allowednames = [x.lstrip("*").lstrip(".") for x in allowednames]
         self.directories = directories
 
-    def __call__(self, prefix, **kwargs):
-        completion = []
+    def __call__(self, prefix: str, **kwargs: _Ignored) -> list[str]:
+        completion: list[str] = []
         if self.allowednames:
             if self.directories:
                 # Using 'bind' in this and the following commands is a workaround to a bug in bash
@@ -90,17 +100,19 @@ class FilesCompleter(BaseCompleter):
 
 
 class _FilteredFilesCompleter(BaseCompleter):
-    def __init__(self, predicate):
+    predicate: Final[Callable[[str], bool]]
+
+    def __init__(self, predicate: Callable[[str], bool]) -> None:
         """
         Create the completer
 
         A predicate accepts as its only argument a candidate path and either
         accepts it or rejects it.
         """
-        assert predicate, "Expected a callable predicate"
+        assert predicate, "Expected a callable predicate"  # type: ignore[truthy-function]
         self.predicate = predicate
 
-    def __call__(self, prefix, **kwargs):
+    def __call__(self, prefix: str, **kwargs: _Ignored) -> Generator[str]:
         """
         Provide completions on prefix
         """
@@ -121,7 +133,7 @@ class _FilteredFilesCompleter(BaseCompleter):
 
 
 class DirectoriesCompleter(_FilteredFilesCompleter):
-    def __init__(self):
+    def __init__(self) -> None:
         _FilteredFilesCompleter.__init__(self, predicate=os.path.isdir)
 
 
@@ -130,10 +142,10 @@ class SuppressCompleter(BaseCompleter):
     A completer used to suppress the completion of specific arguments
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def suppress(self):
+    def suppress(self) -> bool:
         """
         Decide if the completion should be suppressed
         """

--- a/argcomplete/finders.py
+++ b/argcomplete/finders.py
@@ -6,8 +6,8 @@
 import argparse
 import os
 import sys
-from collections.abc import Mapping
-from typing import Callable, Dict, List, Optional, Sequence, TextIO, Union
+from collections.abc import Container, Mapping
+from typing import Callable, Literal, TextIO
 
 from . import io as _io
 from .completers import BaseCompleter, ChoicesCompleter, FilesCompleter, SuppressCompleter
@@ -26,28 +26,42 @@ safe_actions = {
 }
 
 
-def default_validator(completion, prefix):
+def default_validator(completion: str, prefix: str) -> bool:
     return completion.startswith(prefix)
 
 
-class CompletionFinder(object):
+class CompletionFinder:
     """
     Inherit from this class if you wish to override any of the stages below. Otherwise, use
     ``argcomplete.autocomplete()`` directly (it's a convenience instance of this class). It has the same signature as
     :meth:`CompletionFinder.__call__()`.
     """
 
+    _parser: argparse.ArgumentParser | None
+    _formatter: argparse.HelpFormatter | None
+    always_complete_options: bool | Literal["long", "short"]
+    exclude: Container[str] | None
+    validator: Callable[[str, str], bool]
+    print_suppressed: bool
+    completing: bool
+    _display_completions: dict[str, str]
+    default_completer: BaseCompleter
+    append_space: bool
+
+    active_parsers: list[argparse.ArgumentParser]
+    visited_positionals: list[argparse.Action]
+
     def __init__(
         self,
-        argument_parser=None,
-        always_complete_options=True,
-        exclude=None,
-        validator=None,
-        print_suppressed=False,
-        default_completer=FilesCompleter(),
-        append_space=None,
-    ):
-        self._parser = argument_parser
+        argument_parser: argparse.ArgumentParser | None = None,
+        always_complete_options: bool | Literal["long", "short"] = True,
+        exclude: Container[str] | None = None,
+        validator: Callable[[str, str], bool] | None = None,
+        print_suppressed: bool = False,
+        default_completer: BaseCompleter = FilesCompleter(),
+        append_space: bool | None = None,
+    ) -> None:
+        self._parser = argument_parser  # type: ignore[assignment]
         self._formatter = None
         self.always_complete_options = always_complete_options
         self.exclude = exclude
@@ -56,7 +70,7 @@ class CompletionFinder(object):
         self.validator = validator
         self.print_suppressed = print_suppressed
         self.completing = False
-        self._display_completions: Dict[str, str] = {}
+        self._display_completions = {}
         self.default_completer = default_completer
         if append_space is None:
             append_space = os.environ.get("_ARGCOMPLETE_SUPPRESS_SPACE") != "1"
@@ -65,13 +79,13 @@ class CompletionFinder(object):
     def __call__(
         self,
         argument_parser: argparse.ArgumentParser,
-        always_complete_options: Union[bool, str] = True,
+        always_complete_options: bool | str = True,
         exit_method: Callable = os._exit,
-        output_stream: Optional[TextIO] = None,
-        exclude: Optional[Sequence[str]] = None,
-        validator: Optional[Callable] = None,
+        output_stream: TextIO | None = None,
+        exclude: Container[str] | None = None,
+        validator: Callable[[str, str], bool] | None = None,
         print_suppressed: bool = False,
-        append_space: Optional[bool] = None,
+        append_space: bool | None = None,
         default_completer: BaseCompleter = FilesCompleter(),
     ) -> None:
         """
@@ -158,6 +172,7 @@ class CompletionFinder(object):
         start = int(os.environ["_ARGCOMPLETE"]) - 1
         comp_words = comp_words[start:]
 
+        assert self._parser is not None
         if cword_prefix and cword_prefix[0] in self._parser.prefix_chars and "=" in cword_prefix:
             # Special case for when the current word is "--optional=PARTIAL_VALUE". Give the optional to the parser.
             comp_words.append(cword_prefix.split("=", 1)[0])
@@ -211,6 +226,7 @@ class CompletionFinder(object):
         try:
             debug("invoking parser with", comp_words[1:])
             with mute_stderr():
+                assert self._parser is not None
                 a = self._parser.parse_known_args(comp_words[1:], namespace=parsed_args)
             debug("parsed args:", a)
         except BaseException as e:
@@ -233,8 +249,8 @@ class CompletionFinder(object):
         figure out which subparsers need to be activated (then recursively monkey-patch those).
         We save all active ArgumentParsers to extract all their possible option names later.
         """
-        self.active_parsers: List[argparse.ArgumentParser] = []
-        self.visited_positionals: List[argparse.Action] = []
+        self.active_parsers = []
+        self.visited_positionals = []
 
         completer = self
 
@@ -289,12 +305,14 @@ class CompletionFinder(object):
             return ""
         if "%" not in action.help:
             return action.help
-        if self._formatter is None:
-            self._formatter = self._parser.formatter_class(prog=self._parser.prog)
-        return self._formatter._expand_help(action)
+        formatters = self._formatter
+        if formatters is None:
+            assert self._parser is not None
+            self._formatter = formatters = self._parser.formatter_class(prog=self._parser.prog)
+        return formatters._expand_help(action)
 
     def _get_subparser_completions(self, parser, cword_prefix):
-        aliases_by_parser: Dict[argparse.ArgumentParser, List[str]] = {}
+        aliases_by_parser: dict[argparse.ArgumentParser, list[str]] = {}
         for key in parser.choices.keys():
             p = parser.choices[key]
             aliases_by_parser.setdefault(p, []).append(key)
@@ -433,15 +451,15 @@ class CompletionFinder(object):
         return completions
 
     def collect_completions(
-        self, active_parsers: List[argparse.ArgumentParser], parsed_args: argparse.Namespace, cword_prefix: str
-    ) -> List[str]:
+        self, active_parsers: list[argparse.ArgumentParser], parsed_args: argparse.Namespace, cword_prefix: str
+    ) -> list[str]:
         """
         Visits the active parsers and their actions, executes their completers or introspects them to collect their
         option strings. Returns the resulting completions as a list of strings.
 
         This method is exposed for overriding in subclasses; there is no need to use it directly.
         """
-        completions: List[str] = []
+        completions: list[str] = []
 
         debug("all active parsers:", active_parsers)
         active_parser = active_parsers[-1]
@@ -488,7 +506,7 @@ class CompletionFinder(object):
 
         return None
 
-    def filter_completions(self, completions: List[str]) -> List[str]:
+    def filter_completions(self, completions: list[str]) -> list[str]:
         """
         De-duplicates completions and excludes those specified by ``exclude``.
         Returns the filtered completions as a list.
@@ -505,8 +523,8 @@ class CompletionFinder(object):
         return filtered_completions
 
     def quote_completions(
-        self, completions: List[str], cword_prequote: str, last_wordbreak_pos: Optional[int]
-    ) -> List[str]:
+        self, completions: list[str], cword_prequote: str, last_wordbreak_pos: int | None
+    ) -> list[str]:
         """
         If the word under the cursor started with a quote (as indicated by a nonempty ``cword_prequote``), escapes
         occurrences of that quote character in the completions, and adds the quote to the beginning of each completion.
@@ -570,7 +588,7 @@ class CompletionFinder(object):
 
         return escaped_completions
 
-    def rl_complete(self, text, state):
+    def rl_complete(self, text: str, state: int) -> str | None:
         """
         Alternate entry point for using the argcomplete completer in a readline-based REPL. See also
         `rlcompleter <https://docs.python.org/3/library/rlcompleter.html#completer-objects>`_.
@@ -598,7 +616,7 @@ class CompletionFinder(object):
         else:
             return None
 
-    def get_display_completions(self):
+    def get_display_completions(self) -> dict[str, str]:
         """
         This function returns a mapping of completions to their help strings for displaying to the user.
         """

--- a/argcomplete/io.py
+++ b/argcomplete/io.py
@@ -1,19 +1,20 @@
 import contextlib
 import os
 import sys
+from collections.abc import Generator
 
 _DEBUG = "_ARC_DEBUG" in os.environ
 
 debug_stream = sys.stderr
 
 
-def debug(*args):
+def debug(*args: object) -> None:
     if _DEBUG:
         print(file=debug_stream, *args)
 
 
 @contextlib.contextmanager
-def mute_stdout():
+def mute_stdout() -> Generator[None]:
     stdout = sys.stdout
     sys.stdout = open(os.devnull, "w")
     try:
@@ -23,7 +24,7 @@ def mute_stdout():
 
 
 @contextlib.contextmanager
-def mute_stderr():
+def mute_stderr() -> Generator[None]:
     stderr = sys.stderr
     sys.stderr = open(os.devnull, "w")
     try:
@@ -33,7 +34,7 @@ def mute_stderr():
         sys.stderr = stderr
 
 
-def warn(*args):
+def warn(*args: object) -> None:
     """
     Prints **args** to standard error when running completions. This will interrupt the user's command line interaction;
     use it to indicate an error condition that is preventing your completer from working.

--- a/argcomplete/lexers.py
+++ b/argcomplete/lexers.py
@@ -5,7 +5,7 @@ from .io import debug
 from .packages import _shlex
 
 
-def split_line(line, point=None):
+def split_line(line: str, point: int | None = None) -> tuple[str, str, str, list[str], int | None]:
     if point is None:
         point = len(line)
     line = line[:point]
@@ -14,7 +14,7 @@ def split_line(line, point=None):
     lexer.wordbreaks = os.environ.get("_ARGCOMPLETE_COMP_WORDBREAKS", "")
     words = []
 
-    def split_word(word):
+    def split_word(word: str) -> tuple[str, str, str, list[str], int | None]:
         # TODO: make this less ugly
         point_in_word = len(word) + point - lexer.instream.tell()
         if isinstance(lexer.state, (str, bytes)) and lexer.state in lexer.whitespace:

--- a/argcomplete/scripts/activate_global_python_argcomplete.py
+++ b/argcomplete/scripts/activate_global_python_argcomplete.py
@@ -32,7 +32,9 @@ source "{activator}"
 # End added by argcomplete
 """
 
-parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+parser: argparse.ArgumentParser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+)
 parser.add_argument("-y", "--yes", help="automatically answer yes for all questions", action="store_true")
 parser.add_argument("--dest", help='Specify the shell completion modules directory to install into, or "-" for stdout')
 parser.add_argument("--user", help="Install into user directory", action="store_true")
@@ -40,18 +42,18 @@ argcomplete.autocomplete(parser)
 args = None
 
 
-def get_local_dir():
+def get_local_dir() -> str:
     try:
         return subprocess.check_output(["brew", "--prefix"]).decode().strip()
     except (FileNotFoundError, subprocess.CalledProcessError):
         return "/usr/local"
 
 
-def get_zsh_system_dir():
+def get_zsh_system_dir() -> str:
     return f"{get_local_dir()}/share/zsh/site-functions"
 
 
-def get_bash_system_dir():
+def get_bash_system_dir() -> str:
     if "BASH_COMPLETION_COMPAT_DIR" in os.environ:
         return os.environ["BASH_COMPLETION_COMPAT_DIR"]
     elif sys.platform == "darwin":
@@ -60,15 +62,15 @@ def get_bash_system_dir():
         return "/etc/bash_completion.d"  # created by bash-completion
 
 
-def get_activator_dir():
+def get_activator_dir() -> str:
     return os.path.join(os.path.abspath(os.path.dirname(argcomplete.__file__)), "bash_completion.d")
 
 
-def get_activator_path():
+def get_activator_path() -> str:
     return os.path.join(get_activator_dir(), "_python-argcomplete")
 
 
-def install_to_destination(dest):
+def install_to_destination(dest: str) -> None:
     activator = get_activator_path()
     if dest == "-":
         with open(activator) as fh:
@@ -92,7 +94,7 @@ def install_to_destination(dest):
         )
 
 
-def get_consent():
+def get_consent() -> bool:
     assert args is not None
     if args.yes is True:
         return True
@@ -106,7 +108,7 @@ def get_consent():
             return False
 
 
-def append_to_config_file(path, shellcode):
+def append_to_config_file(path: str | os.PathLike[str], shellcode: str) -> None:
     if os.path.exists(path):
         with open(path, 'r') as fh:
             if shellcode in fh.read():
@@ -124,23 +126,23 @@ def append_to_config_file(path, shellcode):
     print("Added.", file=sys.stderr)
 
 
-def link_zsh_user_rcfile(zsh_fpath=None):
+def link_zsh_user_rcfile(zsh_fpath: str | None = None) -> None:
     zsh_rcfile = os.path.join(os.path.expanduser(os.environ.get("ZDOTDIR", "~")), ".zshenv")
     append_to_config_file(zsh_rcfile, zsh_shellcode.format(zsh_fpath=zsh_fpath or get_activator_dir()))
 
 
-def link_bash_user_rcfile():
+def link_bash_user_rcfile() -> None:
     bash_completion_user_file = os.path.expanduser("~/.bash_completion")
     append_to_config_file(bash_completion_user_file, bash_shellcode.format(activator=get_activator_path()))
 
 
-def link_user_rcfiles():
+def link_user_rcfiles() -> None:
     # TODO: warn if running as superuser
     link_zsh_user_rcfile()
     link_bash_user_rcfile()
 
 
-def add_zsh_system_dir_to_fpath_for_user():
+def add_zsh_system_dir_to_fpath_for_user() -> None:
     if "zsh" not in os.environ.get("SHELL", ""):
         return
     try:
@@ -154,7 +156,7 @@ def add_zsh_system_dir_to_fpath_for_user():
         pass
 
 
-def main():
+def main() -> None:
     global args
     args = parser.parse_args()
 
@@ -190,4 +192,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main())  # type: ignore[func-returns-value]

--- a/argcomplete/scripts/register_python_argcomplete.py
+++ b/argcomplete/scripts/register_python_argcomplete.py
@@ -32,7 +32,7 @@ import argcomplete
 __package__ = "argcomplete.scripts"
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument(
@@ -76,4 +76,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main())  # type: ignore[func-returns-value]

--- a/argcomplete/shell_integration.py
+++ b/argcomplete/shell_integration.py
@@ -3,6 +3,7 @@
 # files with source copies of this package and derivative works is **REQUIRED** as specified by the Apache License.
 # See https://github.com/kislyuk/argcomplete for more info.
 
+from collections.abc import Iterable
 from shlex import quote
 
 bashcode = r"""#compdef %(executables)s
@@ -135,7 +136,13 @@ Register-ArgumentCompleter -Native -CommandName %(executable)s -ScriptBlock {
 shell_codes = {"bash": bashcode, "tcsh": tcshcode, "fish": fishcode, "powershell": powershell_code}
 
 
-def shellcode(executables, use_defaults=True, shell="bash", complete_arguments=None, argcomplete_script=None):
+def shellcode(
+    executables: Iterable[str],
+    use_defaults: bool = True,
+    shell: str = "bash",
+    complete_arguments: Iterable[str] | None = None,
+    argcomplete_script: str | None = None,
+) -> str:
     """
     Provide the shell code required to register a python executable for use with the argcomplete module.
 


### PR DESCRIPTION
Hi there.

I noticed that `argcomplete` was missing some type annotations, with a type coverage of 26.6% (according to `uvx pyrefly coverage check argcomplete --public-only` ([docs](https://pyrefly.org/en/docs/report/))).

I figured I might as will contribute and bring this too 100%, so here I am :). 

Mypy still passes with flying colors, and `pyrefly coverage check` now reports a shiny 100% type coverage:

```console
$ mypy argcomplete
Success: no issues found in 15 source files

$ uvx pyrefly coverage check argcomplete --public-only
 INFO type coverage 100.00% (94 of 94 typable)
```

I realize this might be a bit much for a single PR, so if you want, I could split this up.

Oh and in case you were wondering; I'm a human, and I did not use any AI for this; it's way too much fun to do myself :)