### PR TITLE
Enforce 100% type coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,10 @@ jobs:
       - uses: astral-sh/ruff-action@v4.0.0
         with:
           args: "format --check"
+  pyrefly-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.3.2
+      - name: Pyrefly coverage check
+        run: uvx pyrefly coverage check --public-only --output-format=github argcomplete


### PR DESCRIPTION
Now that `argcomplete` has 100% public type coverage (#554), I figured it might be a good idea to ensure that it stays that way.

This adds a light-weight job to the CI workflow that runs `pyrefly coverage check`, which will exit 1 if the type coverage dips below 100%.

If that ever happens, e.g. because of an API change, or because Pyrefly changed something (which I don't expect will happen), then feel free to ping me :)