### PR TITLE
Exit gracefully when COMP_POINT is not a valid integer

### DIFF
--- a/argcomplete/finders.py
+++ b/argcomplete/finders.py
@@ -160,7 +160,12 @@ class CompletionFinder:
             exit_method(1)
 
         comp_line = os.environ["COMP_LINE"]
-        comp_point = int(os.environ["COMP_POINT"])
+        try:
+            comp_point = int(os.environ["COMP_POINT"])
+        except ValueError:
+            debug("Invalid value for COMP_POINT, quitting [{v}]".format(v=os.environ["COMP_POINT"]))
+            exit_method(1)
+            return
 
         cword_prequote, cword_prefix, cword_suffix, comp_words, last_wordbreak_pos = split_line(comp_line, comp_point)
 

--- a/test/test.py
+++ b/test/test.py
@@ -159,6 +159,17 @@ class TestArgcomplete(unittest.TestCase):
         completions = self.run_completer(p, "prog -", always_complete_options=False)
         self.assertEqual(set(completions), set(["-h", "--help", "--foo", "--bar"]))
 
+    def test_invalid_comp_point(self):
+        p = ArgumentParser()
+        p.add_argument("--foo")
+
+        with TemporaryFile(mode="w+") as t:
+            os.environ["COMP_LINE"] = "prog "
+            os.environ["COMP_POINT"] = ""
+            with self.assertRaises(SystemExit) as cm:
+                autocomplete(p, output_stream=t, exit_method=sys.exit)
+            self.assertEqual(cm.exception.code, 1)
+
     def test_choices(self):
         def make_parser():
             parser = ArgumentParser()


### PR DESCRIPTION
Closes #521

Some environments invoke a completion-enabled entry point with `COMP_POINT` set to an empty string, and `CompletionFinder.__call__` called `int()` on it unguarded, so `ValueError` escaped into the application and crashed it (reported via traitlets/IPython on Fedora).

The conversion failure is now handled the same way the neighbouring IFS/DFS validation is: debug message plus `exit_method(1)`. Regression test added; it raises the reported `ValueError` without the fix and passes with it.