### PR TITLE
Fix for kislyuk#544 => TestZshGlobalExplicit tests are failing after upgrade to zsh 5.9.0.1 

### DIFF
--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -151,7 +151,7 @@ _python_argcomplete_global() {
         local_words=( ${(z)BUFFER} )
         executable="${local_words[1]}"
         __python_argcomplete_expand_tilde_by_ref executable
-	req_argv=( "${local_words[@]:1}" )
+        req_argv=( "${local_words[@]:1}" )
     fi
 
     local ARGCOMPLETE=0

--- a/argcomplete/bash_completion.d/_python-argcomplete
+++ b/argcomplete/bash_completion.d/_python-argcomplete
@@ -145,9 +145,13 @@ _python_argcomplete_global() {
         req_argv=( "" "${COMP_WORDS[@]:1}" )
         __python_argcomplete_expand_tilde_by_ref executable
     else
-        executable="${words[1]}"
+        # Reconstruct the unshifted words array from BUFFER to handle cases where
+        # a helper completion function (like _python) has shifted the words array.
+        local -a local_words
+        local_words=( ${(z)BUFFER} )
+        executable="${local_words[1]}"
         __python_argcomplete_expand_tilde_by_ref executable
-        req_argv=( "${words[@]:1}" )
+	req_argv=( "${local_words[@]:1}" )
     fi
 
     local ARGCOMPLETE=0


### PR DESCRIPTION
In recent zsh versions 5.9+ the standard command-completion (such as _python)
shifts the shell's native words array.

This caused _python_argcomplete_global to parse ./prog as the main executable
rather than python3, setting _ARGCOMPLETE=1

Since the bufffer was not shifted, it still contained python3 as the first word
resulting in a parser mismatch and an invalid choice error from argparse
(which also outputs color escape sequences in Python 3.15)

the fix reconstruct the unshifted word list from BUFFER using zsh native
splitting keeping the test suite compatible with newer versions of zsh.

I validated the package build and all 189 tests pass OK (except 12 that were
skipped and 5 expected failures) under Python 3.15 in Fedora rawhide.

Should fix below bug:
A few TestZshGlobalExplicit tests are failing after upgrade to zsh 5.9.0.1 kislyuk#544

Testing is needed, I used the same patch in Fedora to fix the build/tests issue.

Signed-off-by: Filipe Rosset <rosset.filipe@gmail.com>