### PR TITLE
Require Python 3.10+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ work for zsh as well.
 
 Python Support
 --------------
-Argcomplete requires Python 3.9+.
+Argcomplete requires Python 3.10+.
 
 Support for other shells
 ------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "argcomplete"
 description = "Bash tab completion for argparse"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = { text = "Apache Software License" }
 authors = [{ name = "Andrey Kislyuk"}, {email = "kislyuk@gmail.com" }]
 maintainers = [{ name = "Andrey Kislyuk"}, {email = "kislyuk@gmail.com" }]
@@ -15,7 +15,6 @@ classifiers = [
   "Operating System :: POSIX",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Hi! 👋 This PR raises `requires-python` from `>=3.8` to `>=3.10` and drops the stale classifier. Fixes https://github.com/kislyuk/argcomplete/issues/559.

I noticed with the latest release that `argcomplete` uses unions in type annotations, so importing it raises `TypeError` on Python 3.9 and older. But the published metadata still allowed python 3.8, so resolvers install version 3.7.1 into python 3.9 environments, and any import of `argcomplete` fails there.

Downstream projects that still support 3.9 for some reason would currently need a version exclusion to keep 3.9 jobs working, but a patch release after this PR (and yanking 3.7.1) would let them drop it. Thanks!